### PR TITLE
Feature/implementing gemini news

### DIFF
--- a/weather-app/src/App.jsx
+++ b/weather-app/src/App.jsx
@@ -19,6 +19,8 @@ import fetchCityInfo from "./api/fetchCityInfo";
 import CityInfo from "./components/CityInfo";
 import NewsContent from "./components/NewsContent";
 import fetchNews from "./api/fetchNews";
+import fetchGeminiNews from "./api/fetchGeminiNews"; 
+import GeminiNews from "./components/GeminiNews.jsx";
 
 function App() {
   const [loading, setLoading] = useState(false);
@@ -37,6 +39,10 @@ function App() {
   const [newsData, setNewsData] = useState(null);
   const [newsLoading, setNewsLoading] = useState(false);
   const [newsError, setNewsError] = useState(null);
+  const [geminiNewsData, setGeminiNewsData] = useState(null);
+  const [geminiNewsLoading, setGeminiNewsLoading] = useState(false);
+  const [geminiNewsError, setGeminiNewsError] = useState(null);
+  const [newsSource, setNewsSource] = useState("gemini"); // "newsapi" or "gemini"
 
   // Refs to track dropdown and toggle button elements
   const recentSearchesRef = useRef(null);
@@ -59,6 +65,7 @@ function App() {
     getBackgroundData("Kathmandu");
     getCityInfoData("Kathmandu");
     getNewsData("Kathmandu");
+    fetchGeminiNewsData("Kathmandu");
   }, []);
 
   // Fetch AQI data when weather data is available
@@ -115,18 +122,16 @@ function App() {
     try {
       setNewsLoading(true);
       setNewsError(null);
-
-      const result = await fetchNews(city);
-      
-      if (result.success) {
-        // If the fetch is successful, update the news data state
-        setNewsData(result.data);
+      fetchGeminiNewsData(city)
+       const newsResult = await fetchNews(city);
+      if (newsResult.success) {
+        setNewsData(newsResult.data);
       } else {
-        // If the fetch fails, set the error state 
-        setNewsError(result.error);
+        setNewsError(newsResult.error);
         setTimeout(() => {
           setNewsError(null);
         }, 5000);
+        setNewsSource("gemini");
       }
     } catch (error) {
       console.error("Error fetching news:", error);
@@ -135,11 +140,29 @@ function App() {
         setNewsError(null);
       }, 5000);
     } finally {
-      // This is important to stop showing the loading spinner
       setNewsLoading(false);
     }
   };
   
+  // Fetch news data using Gemini AI
+  const fetchGeminiNewsData = async (city) => {
+  setGeminiNewsLoading(true);
+  setGeminiNewsError(null);
+  setGeminiNewsData(null);
+  try {
+    const result = await fetchGeminiNews(city);
+    if (result.success) {
+      setGeminiNewsData(result.data);
+      console.log("Gemini News Data:", result.data);
+    } else {
+      setGeminiNewsError(result.error);
+    }
+  } catch (error) {
+    setGeminiNewsError(error.message);
+  } finally {
+    setGeminiNewsLoading(false);
+  }
+};
 
   // Handle click outside to close recent searches
   useEffect(() => {
@@ -295,7 +318,7 @@ function App() {
   };
 
   return (
-    <>
+    <div className="flex flex-col items-center justify-center gap-4">
       <WeatherCard>
         <div className="relative h-[450px]">
           <BackgroundImage backgroundData={backgroundData} />
@@ -377,17 +400,52 @@ function App() {
                 />
               )}
               {activeMenu === "NEWS" && (
-                <NewsContent 
-                  newsData={newsData}
-                  loading={newsLoading}
-                  error={newsError}
-                />
+                <>
+
+                  {/* Show NewsContent or GeminiNews based on source */}
+                  {newsSource === "newsapi" && (
+                    <NewsContent
+                      newsData={newsData}
+                      loading={newsLoading}
+                      error={newsError}
+                    />
+                  )}
+                 
+                  {newsSource === "gemini" && (
+                    <GeminiNews
+                      newsData={geminiNewsData}
+                      loading={geminiNewsLoading}
+                      error={geminiNewsError}
+                    />
+                  )}
+                </>
               )}
             </div>
           </div>
         </div>
       </WeatherCard>
-
+       {/* Always show toggle for news sources */}
+        {activeMenu === "NEWS"&& (    
+          <div className="absolute bottom-8 flex gap-2 mb-2">
+          <button
+            className={`px-3 py-1 rounded ${newsSource === "newsapi" ? "bg-blue-500 text-white" : "bg-gray-200 text-blue-500"}`}
+            onClick={() => setNewsSource("newsapi")}
+            disabled={!newsData}
+            title={newsData ? "Show Standard News" : "Standard News not available yet"}
+          >
+            Standard News
+          </button>
+          <button
+            className={`px-3 py-1 rounded ${newsSource === "gemini" ? "bg-blue-500 text-white" : "bg-gray-200 text-blue-500"}`}
+            onClick={() => setNewsSource("gemini")}
+            disabled={!geminiNewsData}
+            title={geminiNewsData ? "Show Gemini AI News" : "Gemini AI News not available yet"}
+          >
+            Gemini AI News
+          </button>
+        </div>)}
+        
+            
       {/* Temperature Chart Loading */}
       {chartLoading && <ChartLoading onClose={handleCloseChart} />}
 
@@ -399,7 +457,8 @@ function App() {
           cityName={weatherData?.name}
         />
       )}
-    </>
+      
+    </div>
   );
 }
 

--- a/weather-app/src/App.jsx
+++ b/weather-app/src/App.jsx
@@ -19,7 +19,6 @@ import fetchCityInfo from "./api/fetchCityInfo";
 import CityInfo from "./components/CityInfo";
 import NewsContent from "./components/NewsContent";
 import fetchNews from "./api/fetchNews";
-import SunriseSunset from "./components/SunriseSunset";
 
 function App() {
   const [loading, setLoading] = useState(false);
@@ -306,7 +305,7 @@ function App() {
             country={country}
             onShowChart={handleShowChart}
           />
-          
+
           {/* Search Bar */}
           <div className="flex flex-col items-center justify-center h-[300px]">
             <SearchBar
@@ -317,7 +316,6 @@ function App() {
             />
           </div>
 
-     
           {/* Toggle Button for Recent Searches */}
           <button
             ref={toggleButtonRef}
@@ -361,7 +359,8 @@ function App() {
             handleActiveMenu={handleActiveMenu}
           />
         </div>        
-          {/* Bottom Section */}
+        
+        {/* Bottom Section */}
         <div className="bg-white/80 px-4 py-4 h-[110px]">
           <div className="h-full w-full flex items-start justify-center overflow-y-auto">
             <div className="w-full max-w-4xl">

--- a/weather-app/src/App.jsx
+++ b/weather-app/src/App.jsx
@@ -19,6 +19,7 @@ import fetchCityInfo from "./api/fetchCityInfo";
 import CityInfo from "./components/CityInfo";
 import NewsContent from "./components/NewsContent";
 import fetchNews from "./api/fetchNews";
+import SunriseSunset from "./components/SunriseSunset";
 
 function App() {
   const [loading, setLoading] = useState(false);
@@ -305,7 +306,7 @@ function App() {
             country={country}
             onShowChart={handleShowChart}
           />
-
+          
           {/* Search Bar */}
           <div className="flex flex-col items-center justify-center h-[300px]">
             <SearchBar
@@ -316,6 +317,7 @@ function App() {
             />
           </div>
 
+     
           {/* Toggle Button for Recent Searches */}
           <button
             ref={toggleButtonRef}
@@ -359,8 +361,7 @@ function App() {
             handleActiveMenu={handleActiveMenu}
           />
         </div>        
-        
-        {/* Bottom Section */}
+          {/* Bottom Section */}
         <div className="bg-white/80 px-4 py-4 h-[110px]">
           <div className="h-full w-full flex items-start justify-center overflow-y-auto">
             <div className="w-full max-w-4xl">

--- a/weather-app/src/api/fetchGeminiNews.js
+++ b/weather-app/src/api/fetchGeminiNews.js
@@ -1,0 +1,87 @@
+import { GoogleGenerativeAI } from "@google/generative-ai";
+import config from "../config/config";
+
+const fetchGeminiNews = async (cityName) => {
+  try {
+    const { GEMINI_API_KEY } = config;
+
+    if (!GEMINI_API_KEY) {
+      throw new Error("Gemini API key not found");
+    }
+
+    // Initialize Gemini AI News
+    const genAI = new GoogleGenerativeAI(GEMINI_API_KEY);
+    const model = genAI.getGenerativeModel({
+      model: "gemini-2.0-flash",
+    });
+
+    // Create prompt for city news information
+    const today = new Date().toISOString().split("T")[0]; // e.g., "2025-06-15"
+    const prompt = `Provide the latest 6 relevant news articles for the city: "${cityName} as of ${today}".
+
+Return the result in the following JSON format:
+
+{
+  "city": "${cityName}",
+  "news": [
+    {
+      "title": "Headline of the article",
+      "date": "YYYY-MM-DD",
+      "description": "2-3 sentence summary of the article."
+    },
+    ...
+  ]
+}
+
+Only include news directly related to the city. Ensure the output is valid JSON with exactly 6 news articles.`;
+
+    // Generate content
+    const result = await model.generateContent(prompt);
+    const response = result?.response;
+    const text = response.text();
+    console.log("Gemini AI news Response:", text);
+
+    try {
+      // Try to parse JSON from the response
+      let cleanedText = text.replace(/```json\n?|\n?```/g, "").trim();
+      let parsed;
+      try {
+        parsed = JSON.parse(cleanedText);
+      } catch (parseError) {
+        // Fallback: extract the first JSON object from the text
+        const objectMatch = cleanedText.match(/\{[\s\S]*\}/);
+        if (objectMatch) {
+          try {
+            parsed = JSON.parse(objectMatch[0]);
+          } catch (innerError) {
+            console.error("Error parsing extracted JSON object:", innerError);
+            throw new Error("Failed to parse city news (invalid JSON object)");
+          }
+        } else {
+          console.error("Error parsing AI response:", parseError);
+          throw new Error("Failed to parse city news (no JSON object found)");
+        }
+      }
+
+      if (!parsed.city || !Array.isArray(parsed.news)) {
+        throw new Error("Response format is invalid or incomplete.");
+      }
+
+      return {
+        success: true,
+        data: parsed,
+      };
+    } catch (parseError) {
+      console.error("Error parsing AI response:", parseError);
+      throw new Error("Failed to parse city news");
+    }
+  } catch (error) {
+    console.error("Error fetching city news:", error);
+    return {
+      success: false,
+      error: error.message || "Failed to fetch Gemini news",
+    };
+  }
+};
+
+export default fetchGeminiNews;

--- a/weather-app/src/components/GeminiNews.jsx
+++ b/weather-app/src/components/GeminiNews.jsx
@@ -1,0 +1,148 @@
+import React, { useState, useRef, useEffect } from "react";
+
+
+/**
+ * GeminiNews - Grid display with animated title and modal for details.
+ *
+ * @param {Object} newsData - Object of news articles ({ city, news: [{ title, description, date }] })
+ * @param {boolean} loading - Whether news is being loaded
+ * @param {string} error - Error message, if any
+ */
+const GeminiNews = ({ newsData, loading, error }) => {
+  const [selectedArticle, setSelectedArticle] = useState(null);
+  const [showContent, setShowContent] = useState(false);
+
+
+  // Handles click to open modal
+  const handleCardClick = (article) => {
+    setSelectedArticle(article);
+    setShowContent(true); // Show the modal content
+  };
+
+  // Handles closing the modal
+  const handleCloseModal = () => {
+    setSelectedArticle(null);
+    setShowContent(false); // Hide the modal content
+  };
+
+  // Ref for modal content
+  const modalRef = useRef(null);
+ // Handle click outside to close recent searches
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (
+        showContent &&   // Check if recent searches panel is open
+        modalRef.current && // modal element exists
+        !modalRef.current.contains(event.target) // Click not in modal
+      ) {
+        setShowContent(false); //close the dropdown
+      }
+    };
+
+    //Only Add event listener when panel is open
+    if (showContent) {
+      document.addEventListener("mousedown", handleClickOutside);
+    }
+
+    // Cleanup event listener
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  
+  }, [showContent]);
+
+
+  return (
+    <div className="flex flex-col w-full">
+      {loading && (
+        <div className="text-center text-gray-500 py-4">Loading news...</div>
+      )}
+      {error && (
+        <div className="text-center text-red-500 py-4">{error}</div>
+      )}
+      {!loading &&
+        !error &&
+        newsData &&
+        Array.isArray(newsData.news) &&
+        newsData.news.length > 0 && (
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 ">
+            {newsData.news.map((article, idx) => (
+              <button
+                key={idx}
+                type="button"
+                className="flex flex-col items-center text-center h-[75px] hover:bg-gray-500 rounded-lg p-0.5 transition-colors relative"
+
+                onClick={() => handleCardClick(article)}
+               
+              >
+                <div className="relative w-full aspect-video overflow-hidden rounded-lg bg-gray-100">
+                  <div
+                    className={`absolute top-0 left-0 w-full h-[80px]  bg-white  flex items-center justify-center  `}
+                  >
+                    <h3 className="text-xs font-medium text-gray-800 leading-snug px-0.5">
+                      {article.title}
+                    </h3>
+                  </div>
+                </div>
+              </button>
+            ))}
+          </div>
+        )}
+
+      {/* Modal for article details */}
+      {selectedArticle && (
+        <div
+          ref={modalRef}
+          className="fixed inset-0 z-20 flex items-center justify-center bg-black bg-opacity-40"
+          onClick={handleCloseModal}
+        >
+          <div
+            className="bg-white rounded-lg shadow-lg p-6 max-w-md w-full relative"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <ModalComponent
+              article={selectedArticle}
+              onClose={handleCloseModal}
+            />
+          </div>
+        </div>
+      )}
+
+    </div>
+  );
+};
+
+const ModalComponent = ({ article, onClose }) => {
+  return (
+   <>
+        <button
+          className="absolute top-2 right-2 text-gray-400 hover:bg-red-700 hover:text-white rounded-full p-0.5 w-5 h-5 flex items-center justify-center"
+          onClick={onClose}
+          aria-label="Close"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="w-3 h-3"
+            fill="none"
+            viewBox="0 0 12 12"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <line x1="3" y1="3" x2="9" y2="9" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
+            <line x1="9" y1="3" x2="3" y2="9" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
+          </svg>
+        </button>
+        <h3 className="text-lg font-bold text-gray-900 mb-2">
+          {article.title}
+        </h3>
+        {article.date && (
+          <div className="text-xs text-gray-500 mb-2">
+            {article.date}
+          </div>
+        )}
+        <p className="text-gray-700 text-base text-justify">
+          {article.description}
+        </p>
+    </>
+  );
+}
+
+export default GeminiNews;

--- a/weather-app/src/components/SunriseSunset.jsx
+++ b/weather-app/src/components/SunriseSunset.jsx
@@ -1,0 +1,92 @@
+import { useState, useEffect } from 'react';
+
+const SunriseSunset = ({ sunrise, sunset }) => {
+  const [timeUntil, setTimeUntil] = useState({ target: '', hours: 0, minutes: 0, seconds: 0 });
+  const [progress, setProgress] = useState(0);
+
+  const getProgressStyle = (progress, target) => {
+    // Different color schemes for sunrise and sunset with linear gradient for rectangular design
+    if (target === 'sunrise') {
+      return {
+        background: `linear-gradient(to right, 
+          #FF6B6B 0%, 
+          #FFE66D 50%, 
+          #FF8E53 ${progress}%, 
+          rgba(255, 255, 255, 0.15) ${progress}%)`
+      };
+    } else {
+      return {
+        background: `linear-gradient(to right, 
+          #667eea 0%, 
+          #764ba2 50%, 
+          #f093fb ${progress}%, 
+          rgba(255, 255, 255, 0.15) ${progress}%)`
+      };
+    }
+  };
+
+  const calculateTimeUntil = () => {
+    const now = new Date().getTime();
+    const sunriseTime = sunrise * 1000; // Convert to milliseconds
+    const sunsetTime = sunset * 1000;
+
+    // Determine if we're counting to sunrise or sunset
+    let target, timeLeft;
+    if (now < sunriseTime) {
+      target = 'sunrise';
+      timeLeft = sunriseTime - now;
+    } else if (now < sunsetTime) {
+      target = 'sunset';
+      timeLeft = sunsetTime - now;
+    } else {
+      // After sunset, count to next day's sunrise
+      target = 'sunrise';
+      timeLeft = (sunriseTime + 86400000) - now; // Add 24 hours in milliseconds
+    }
+
+    // Calculate hours, minutes, and seconds
+    const hours = Math.floor(timeLeft / (1000 * 60 * 60));
+    const minutes = Math.floor((timeLeft % (1000 * 60 * 60)) / (1000 * 60));
+    const seconds = Math.floor((timeLeft % (1000 * 60)) / 1000);
+
+    // Calculate progress percentage
+    const totalDuration = target === 'sunrise' 
+      ? sunriseTime - (sunsetTime - 86400000) // Previous sunset to sunrise
+      : sunsetTime - sunriseTime; // Sunrise to sunset
+    const elapsed = target === 'sunrise'
+      ? now - (sunsetTime - 86400000)
+      : now - sunriseTime;
+    const newProgress = (elapsed / totalDuration) * 100;
+
+    setTimeUntil({ target, hours, minutes, seconds });
+    setProgress(newProgress);
+  };
+
+  useEffect(() => {
+    calculateTimeUntil();
+    const interval = setInterval(calculateTimeUntil, 1000); // Update every second
+    return () => clearInterval(interval);
+  }, [sunrise, sunset]);
+  
+  return (
+    <div className="relative w-24 h-12 rounded-xl bg-white/10 backdrop-blur-sm border border-white/20" 
+    style={getProgressStyle(progress, timeUntil.target)}
+    >
+      {/* Progress indicator bar */}
+      <div 
+        className="absolute top-0 left-0 h-1 rounded-full transition-all duration-300"
+       
+      />
+      
+      {/* Content */}
+      <div className="flex items-center justify-center h-full">
+        <div className="text-center text-white leading-none">
+          <span className="block text-sm font-bold">{`${timeUntil.hours}h ${timeUntil.minutes}m ${timeUntil.seconds}s`}</span>
+          <span className="text-[12px] opacity-80">until {timeUntil.target}</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SunriseSunset;

--- a/weather-app/src/components/SunriseSunset.jsx
+++ b/weather-app/src/components/SunriseSunset.jsx
@@ -1,12 +1,13 @@
 import { useState, useEffect } from 'react';
 
 const SunriseSunset = ({ sunrise, sunset }) => {
-  const [timeUntil, setTimeUntil] = useState({ target: '', hours: 0, minutes: 0, seconds: 0 });
+  const [timeUntil, setTimeUntil] = useState({ target: '', hours: 0, minutes: 0, seconds: 0 }); 
   const [progress, setProgress] = useState(0);
 
   const getProgressStyle = (progress, target) => {
     // Different color schemes for sunrise and sunset with linear gradient for rectangular design
     if (target === 'sunrise') {
+       // Sunrise colors: warm tones (coral -> yellow -> orange)
       return {
         background: `linear-gradient(to right, 
           #FF6B6B 0%, 
@@ -15,6 +16,7 @@ const SunriseSunset = ({ sunrise, sunset }) => {
           rgba(255, 255, 255, 0.15) ${progress}%)`
       };
     } else {
+       // Sunset colors: cool tones (blue -> purple -> pink)
       return {
         background: `linear-gradient(to right, 
           #667eea 0%, 
@@ -24,9 +26,9 @@ const SunriseSunset = ({ sunrise, sunset }) => {
       };
     }
   };
-
+  // Calculate the time until sunrise or sunset
   const calculateTimeUntil = () => {
-    const now = new Date().getTime();
+    const now = new Date().getTime(); // Get the current time in milliseconds
     const sunriseTime = sunrise * 1000; // Convert to milliseconds
     const sunsetTime = sunset * 1000;
 
@@ -70,14 +72,9 @@ const SunriseSunset = ({ sunrise, sunset }) => {
   
   return (
     <div className="relative w-24 h-12 rounded-xl bg-white/10 backdrop-blur-sm border border-white/20" 
-    style={getProgressStyle(progress, timeUntil.target)}
+    style={getProgressStyle(progress, timeUntil.target)}  //progress style
     >
-      {/* Progress indicator bar */}
-      <div 
-        className="absolute top-0 left-0 h-1 rounded-full transition-all duration-300"
-       
-      />
-      
+      <div className="absolute top-0 left-0 h-1 rounded-full transition-all duration-300"/>
       {/* Content */}
       <div className="flex items-center justify-center h-full">
         <div className="text-center text-white leading-none">

--- a/weather-app/src/components/WeatherContent.jsx
+++ b/weather-app/src/components/WeatherContent.jsx
@@ -2,42 +2,46 @@ import React from "react";
 
 const WeatherContent = ({ weatherData }) => {
   return (
-    <div className="flex flex-row justify-between gap-4 w-full">
-      <div className="flex-1 flex flex-col items-center">
-        <div className="flex items-center gap-4">
-          <span className="text-3xl font-medium text-gray-800">
-            {weatherData?.main.temp}°C
-          </span>
+    <div className="flex flex-col gap-6 w-full">
+      <div className="flex flex-row justify-between gap-4 w-full">
+        <div className="flex-1 flex flex-col items-center">
+          <div className="flex items-center gap-4">
+            <span className="text-3xl font-medium text-gray-800">
+              {weatherData?.main.temp}°C
+            </span>
+          </div>
+          <span className="text-gray-600 mt-2">TEMPERATURE</span>
         </div>
-        <span className="text-gray-600 mt-2">TEMPERATURE</span>
-      </div>
 
-      <div className="flex-1 flex flex-col items-center">
-        <div className="flex items-center gap-4">
-          <span className="text-3xl font-medium text-gray-800">
-            {weatherData?.main.humidity}%
-          </span>
+        <div className="flex-1 flex flex-col items-center">
+          <div className="flex items-center gap-4">
+            <span className="text-3xl font-medium text-gray-800">
+              {weatherData?.main.humidity}%
+            </span>
+          </div>
+          <span className="text-gray-600 mt-2">HUMIDITY</span>
         </div>
-        <span className="text-gray-600 mt-2">HUMIDITY</span>
-      </div>
 
-      <div className="flex-1 flex flex-col items-center">
-        <div className="flex items-center gap-4">
-          <span className="text-3xl font-medium text-gray-800">
-            {weatherData?.wind.speed} km/h
-          </span>
+        <div className="flex-1 flex flex-col items-center">
+          <div className="flex items-center gap-4">
+            <span className="text-3xl font-medium text-gray-800">
+              {weatherData?.wind.speed} km/h
+            </span>
+          </div>
+          <span className="text-gray-600 mt-2">WIND</span>
         </div>
-        <span className="text-gray-600 mt-2">WIND</span>
-      </div>
 
-      <div className="flex-1 flex flex-col items-center">
-        <div className="flex items-center gap-4">
-          <span className="text-3xl font-medium text-gray-800">
-            {weatherData?.weather[0].main.toUpperCase()}
-          </span>
+        <div className="flex-1 flex flex-col items-center">
+          <div className="flex items-center gap-4">
+            <span className="text-3xl font-medium text-gray-800">
+              {weatherData?.weather[0].main.toUpperCase()}
+            </span>
+          </div>
+          <span className="text-gray-600 mt-2">CONDITION</span>
         </div>
-        <span className="text-gray-600 mt-2">CONDITION</span>
       </div>
+      
+    
     </div>
   );
 };

--- a/weather-app/src/components/WeatherHeader.jsx
+++ b/weather-app/src/components/WeatherHeader.jsx
@@ -1,12 +1,21 @@
 import React, { useEffect, useState } from "react";
+import SunriseSunset from "./SunriseSunset";
 
 const WeatherHeader = ({ weatherData, localTime, country, onShowChart }) => {
   const [localTimeClock, setLocalTimeClock] = useState(null);
 
   return (
     <>
-      <div className="absolute top-6 left-8 text-white">
+      <div className="absolute top-6 left-6 text-white">
+        
         <div className="flex items-center gap-3">
+             {/* Sunrise Sunset Component*/}
+          {weatherData?.sys?.sunrise && weatherData?.sys?.sunset && (
+              <SunriseSunset 
+                sunrise={weatherData.sys.sunrise} 
+                sunset={weatherData.sys.sunset} 
+              />
+          )}          
           <h1 className="text-3xl font-light">{weatherData?.name}</h1>
           {weatherData?.name && (
             <button
@@ -31,6 +40,9 @@ const WeatherHeader = ({ weatherData, localTime, country, onShowChart }) => {
           )}
         </div>
       </div>
+      
+   
+      
       <div className="absolute top-6 right-8 text-white flex flex-col items-end">
         <div className="flex items-center gap-2">
           <svg

--- a/weather-app/src/components/index.js
+++ b/weather-app/src/components/index.js
@@ -8,4 +8,3 @@ export { default as RecentSearches } from "./RecentSearches";
 export { default as TemperatureCard } from "./TemperatureCard";
 export { default as Chart } from "./Chart";
 export { default as ChartLoading } from "./ChartLoading";
-export { default as SunriseSunset } from "./SunriseSunset";

--- a/weather-app/src/components/index.js
+++ b/weather-app/src/components/index.js
@@ -8,3 +8,4 @@ export { default as RecentSearches } from "./RecentSearches";
 export { default as TemperatureCard } from "./TemperatureCard";
 export { default as Chart } from "./Chart";
 export { default as ChartLoading } from "./ChartLoading";
+export { default as SunriseSunset } from "./SunriseSunset";

--- a/weather-app/src/styles/SunriseSunset.css
+++ b/weather-app/src/styles/SunriseSunset.css
@@ -1,0 +1,66 @@
+.sunrise-sunset-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+  padding: 1rem;
+  background: rgba(255, 255, 255, 0.1);  -webkit-backdrop-filter: blur(10px);
+  backdrop-filter: blur(10px);
+  border-radius: 15px;
+  margin: 1rem 0;
+}
+
+.progress-circle {
+  position: relative;
+  width: 200px;
+  height: 200px;
+  border-radius: 50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: conic-gradient(from 0deg, #FFA500 var(--progress), rgba(255, 255, 255, 0.2) var(--progress));
+}
+
+.inner-circle {
+  position: absolute;
+  width: 160px;
+  height: 160px;
+  background: rgba(0, 0, 0, 0.4);
+  border-radius: 50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.time-display {
+  text-align: center;
+  color: white;
+}
+
+.time-display .time {
+  font-size: 1.5rem;
+  font-weight: bold;
+  display: block;
+}
+
+.time-display .label {
+  font-size: 1rem;
+  opacity: 0.8;
+}
+
+.sun-times {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  color: white;
+}
+
+.sunrise-time, .sunset-time {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.icon {
+  font-size: 1.5rem;
+}


### PR DESCRIPTION
## 📝 Summary

This update makes it easier and more pleasant to browse news articles in the app. You now see only the headlines first, and if you're curious, you can click to read more details in a popup.

## ✨ Changes Made
* The news section now **shows only the titles** in a clean grid layout.
* Clicking on a title will open a **popup (modal)** that shows:
  * 📰 the full title
  * 🗓️ the date
  * 📄 a short summary of the news
* You can **close the popup** by clicking the close button or **anywhere outside it**.
* The popup and news layout work smoothly on both mobile and desktop.



## ✅ Testing steps:
1. **Open the app** and go to the section labeled **"News"**.
2. You’ll see a grid of **news headlines** – no images, just titles.
3. Click on **any headline** you’re interested in.
4. A **popup** will appear showing:

   * The full **title**
   * The **date** of the news
   * A short **description**
5. To **close the popup**, you can either:

   * Click the small ❌ button in the top-right corner, or
   * Click **anywhere outside** the popup
6. Repeat for other headlines if you'd like — every article opens the correct details.

## 🖼️ Screenshots

Before: 
![Screenshot 2025-06-15 200417](https://github.com/user-attachments/assets/377cd918-04ce-4540-a8bc-790b290b066f)
After : ( Selecting "News" )
![Screenshot 2025-06-15 200336](https://github.com/user-attachments/assets/89bbcf81-10da-4543-988f-0d069bdaaffa)

![Screenshot 2025-06-15 200400](https://github.com/user-attachments/assets/76edadeb-10a5-4e11-8a45-6c87b140f104)
