### PR TITLE
Add modal preview, loading screen, and image fallback for NewsFeed

### DIFF
--- a/daily-drip/client/src/App.jsx
+++ b/daily-drip/client/src/App.jsx
@@ -4,6 +4,7 @@ function App() {
   return (
     <div>
       <h1>Top Headlines</h1>
+      <h2 className='text-2xl font-bold'>News Feed</h2>
       <NewsFeed />
     </div>
    

--- a/daily-drip/client/src/components/Modal.jsx
+++ b/daily-drip/client/src/components/Modal.jsx
@@ -1,0 +1,55 @@
+// src/components/Modal.jsx
+import { useEffect } from 'react'
+
+const Modal = ({ isOpen, onClose, article }) => {
+    useEffect(() => {
+        const handleEsc = (e) => {
+          if (e.key === 'Escape') onClose()
+        }
+    
+        if (isOpen) {
+          document.addEventListener('keydown', handleEsc)
+        }
+    
+        return () => {
+          document.removeEventListener('keydown', handleEsc)
+        }
+      }, [isOpen, onClose])
+    if (!isOpen || !article) return null; // If modal is not open or no article, show nothing
+  
+    return (
+      <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+        <div className="bg-white p-4 rounded-lg max-w-xl w-full relative">
+          {/* Close button */}
+          <button onClick={onClose} className="absolute top-2 right-2 text-gray-500">✕</button>
+  
+          {/* Article content */}
+          <h2 className="text-xl font-bold">{article.title}</h2>
+  
+          {article.urlToImage && (
+            <img src={article.urlToImage} alt="News" className="w-full my-2 rounded" />
+          )}
+  
+          <p className="text-sm text-gray-500 mb-2">
+            {article.source?.name} • {new Date(article.publishedAt).toLocaleString()}
+          </p>
+  
+          <p>{article.description || "No description available."}</p>
+  
+          {article.url && (
+            <a
+              href={article.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-600 mt-2 inline-block"
+            >
+              Read more →
+            </a>
+          )}
+        </div>
+      </div>
+    );
+  };
+  
+  export default Modal;
+  

--- a/daily-drip/client/src/components/NewsFeed.jsx
+++ b/daily-drip/client/src/components/NewsFeed.jsx
@@ -1,10 +1,12 @@
 // src/components/NewsFeed.jsx
 import { useEffect, useState } from 'react'
 import axios from 'axios'
+import Modal from './Modal'
 
 const NewsFeed = () => {
   const [articles, setArticles] = useState([])
   const [loading, setLoading] = useState(true)
+  const [selectedArticle, setSelectedArticle] = useState(null)
 
   useEffect(() => {
     const fetchNews = async () => {
@@ -21,21 +23,39 @@ const NewsFeed = () => {
     fetchNews()
   }, [])
 
-  if (loading) return <p>Loading...</p>
+  if (loading) return (
+    <div className="flex flex-col items-center justify-center h-screen text-center">
+      <div className="animate-spin text-4xl">📰</div>
+      <p className="mt-4 text-gray-600 text-lg">Fetching fresh headlines...</p>
+    </div>
+  )
 
   return (
     <div className="news-feed">
       {articles.map((article, index) => (
-        <div className="news-card" key={index}>
-          <img
-            src={article.urlToImage || '/fallback.jpg'}
-            alt="news"
-            width="300"
-          />
+        <div className="news-card" key={index} onClick={() => setSelectedArticle(article)}>
+          {article.urlToImage ? (
+            <img
+              src={article.urlToImage}
+              alt={article.title || "news"}
+              width="300"
+              onError={(e) => { e.target.src = '/fallback.jpg' }}
+            />
+          ) : (
+            <div className="w-[300px] h-[200px] bg-gray-200 flex items-center justify-center text-gray-500 italic">
+              No image
+            </div>
+          )}
           <h2>{article.title}</h2>
           <p><strong>{article.source.name}</strong> – {new Date(article.publishedAt).toLocaleDateString()}</p>
         </div>
       ))}
+
+      <Modal
+        isOpen={!!selectedArticle}
+        onClose={() => setSelectedArticle(null)}
+        article={selectedArticle}
+      />
     </div>
   )
 }


### PR DESCRIPTION
This PR introduces the following improvements:

- Adds a modal component to show full article details on card click
- Implements a creative loading state with animation and message
- Handles missing or broken images with a fallback placeholder or styled box

These changes enhance the overall user experience and make the NewsFeed more robust.
