### PR TITLE
183 feat add transaction list

### DIFF
--- a/PBL1/Spendly-Project/frontend/package.json
+++ b/PBL1/Spendly-Project/frontend/package.json
@@ -14,7 +14,9 @@
     "@fortawesome/free-brands-svg-icons": "^7.0.0",
     "@fortawesome/free-solid-svg-icons": "^7.0.0",
     "@fortawesome/react-fontawesome": "^0.2.3",
+    "date-fns": "^4.1.0",
     "react": "^19.1.0",
+    "react-date-range": "^2.0.1",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.7.1"
   },

--- a/PBL1/Spendly-Project/frontend/src/App.css
+++ b/PBL1/Spendly-Project/frontend/src/App.css
@@ -2,9 +2,10 @@
   margin:0;
   padding: 0;
 }
-
 .appContainer{
   z-index: 10;
   min-height: 100vh;
+  overflow: auto;
+  overflow-x: hidden;
   background-color: #00160D;
 }

--- a/PBL1/Spendly-Project/frontend/src/App.jsx
+++ b/PBL1/Spendly-Project/frontend/src/App.jsx
@@ -1,9 +1,9 @@
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import Navbar from "./components/Navbar/Navbar";
-import Expense from "./components/Add-Expense/Expense"
 
 import "./App.css";
 import Sidebar from "./components/Sidebar/Sidebar";
+import TransactionList from "./features/Transaction/TransactionList";
 
 function App() {
   return (
@@ -11,10 +11,11 @@ function App() {
       <Router>
         <div className="appContainer">
           <Navbar />
-
           <Sidebar />
-
-          <Expense />
+          <Routes>
+            <Route path="/transaction" element={<TransactionList />}></Route>
+          </Routes>
+          <TransactionList />
         </div>
       </Router>
     </>

--- a/PBL1/Spendly-Project/frontend/src/components/Data/Expense.js
+++ b/PBL1/Spendly-Project/frontend/src/components/Data/Expense.js
@@ -1,0 +1,89 @@
+const Expense = [
+  {
+    "amount": 15.99,
+    "description": "Lunch at Burger Shack",
+    "category": "Food",
+    "date": "2025-08-01"
+  },
+  {
+    "amount": 120.00,
+    "description": "Bus ticket to Pokhara",
+    "category": "Travel",
+    "date": "2025-07-29"
+  },
+  {
+    "amount": 35.50,
+    "description": "Udemy course on React",
+    "category": "Education",
+    "date": "2025-07-25"
+  },
+  {
+    "amount": 8.75,
+    "description": "Coffee with friend",
+    "category": "Food",
+    "date": "2025-08-02"
+  },
+  {
+    "amount": 250.00,
+    "description": "Hotel stay for 2 nights",
+    "category": "Travel",
+    "date": "2025-07-30"
+  },
+  {
+    "amount": 99.00,
+    "description": "Online subscription - Annual",
+    "category": "Education",
+    "date": "2025-07-15"
+  },
+  {
+    "amount": 42.30,
+    "description": "Groceries from Mart",
+    "category": "Food",
+    "date": "2025-08-03"
+  },
+  {
+    "amount": 15.99,
+    "description": "Lunch at Burger Shack",
+    "category": "Food",
+    "date": "2025-08-01"
+  },
+  {
+    "amount": 120.00,
+    "description": "Bus ticket to Pokhara",
+    "category": "Travel",
+    "date": "2025-07-29"
+  },
+  {
+    "amount": 350000.50,
+    "description": "Udemy course on React",
+    "category": "Education",
+    "date": "2025-07-25"
+  },
+  {
+    "amount": 8000.75,
+    "description": "Coffee with friend",
+    "category": "Food",
+    "date": "2025-08-02"
+  },
+  {
+    "amount": 2500000.00,
+    "description": "Hotel stay for 2 nights",
+    "category": "Travel",
+    "date": "2025-07-30"
+  },
+  {
+    "amount": 10000.00,
+    "description": "Online subscription - Annual",
+    "category": "Education",
+    "date": "2025-07-15"
+  },
+  {
+    "amount": 420000.30,
+    "description": "Groceries from Mart",
+    "category": "Food",
+    "date": "2025-08-03"
+  }
+]
+
+
+export default Expense;

--- a/PBL1/Spendly-Project/frontend/src/features/Filter/filter.js
+++ b/PBL1/Spendly-Project/frontend/src/features/Filter/filter.js
@@ -1,0 +1,10 @@
+const filterByDateRange = (expenses, start, end) => {
+    if(!start && !end) return expenses;
+
+    return expenses.filter((e) => {
+        const expenseDate = new Date(e.date);
+        return(!start || expenseDate >= new Date(start)) && (!end || expenseDate <= new Date(end));
+    })
+}
+
+export default filterByDateRange;

--- a/PBL1/Spendly-Project/frontend/src/features/Transaction/Calender.jsx
+++ b/PBL1/Spendly-Project/frontend/src/features/Transaction/Calender.jsx
@@ -1,0 +1,41 @@
+import { useState } from "react";
+import "react-date-range/dist/styles.css"; // main style file
+import "react-date-range/dist/theme/default.css"; // theme css file
+
+import { DateRange } from "react-date-range";
+
+import { addDays } from "date-fns";
+import "./CalenderTheme.css"
+
+function Calender({onRangeChange}) {
+  const [state, setState] = useState([
+    {
+      startDate: new Date(),
+      endDate: addDays(new Date(), 7),
+      key: "selection",
+    },
+  ]);
+
+const handleSelect = (ranges) => {
+  const {startDate, endDate} = ranges.selection;
+  setState([ranges.selection]);
+  onRangeChange(startDate, endDate);
+}
+
+  return (
+    <>
+      <div
+        style={{ display: "flex", justifyContent: "center", marginTop: "2rem" }}
+      >
+        <DateRange
+          editableDateInputs={true}
+          onChange={handleSelect}
+          moveRangeOnFirstSelection={false}
+          ranges={state}
+        />
+      </div>
+    </>
+  );
+}
+
+export default Calender;

--- a/PBL1/Spendly-Project/frontend/src/features/Transaction/CalenderTheme.css
+++ b/PBL1/Spendly-Project/frontend/src/features/Transaction/CalenderTheme.css
@@ -1,0 +1,88 @@
+/* === Base Wrapper === */
+.rdrCalendarWrapper {
+  background-color: #002218;
+  color: #ffffff;
+  border-radius: 12px;
+  padding: 12px;
+  font-family: 'Roboto', sans-serif;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.25);
+  position: absolute;
+  top: 19%;
+  left: 15%;
+  z-index: 100;
+}
+
+/* === Header (Month, Year, Arrows) === */
+.rdrMonthAndYearWrapper {
+  background: none;
+  color: #ffffff;
+  font-weight: 500;
+}
+
+.rdrMonthAndYearPickers select {
+  background-color: #152F29;
+  color: #ffffff;
+  border: none;
+  padding: 4px;
+  border-radius: 4px;
+}
+
+/* === Week Days === */
+.rdrWeekDays {
+  color: #cccccc;
+  font-weight: 400;
+  font-size: 14px;
+}
+
+/* === Days === */
+.rdrDayNumber span {
+  color: #ffffff;
+}
+
+/* === Today Circle (MUI-style) === */
+.rdrDayToday .rdrDayNumber span {
+  border: 1px solid #285E61;
+  border-radius: 50%;
+}
+
+/* === Range Selection Styling (Pill style) === */
+.rdrInRange,
+.rdrStartEdge,
+.rdrEndEdge {
+  background-color: #285E61 !important;
+  color: #ffffff !important;
+  border-radius: 16px !important; /* Pill shape */
+}
+
+/* === Hover Preview === */
+.rdrDay:hover:not(.rdrDayPassive) {
+  background-color: #285E61;
+  color: #ffffff;
+}
+
+/* === Passive (other-month) Days === */
+.rdrDayPassive .rdrDayNumber span {
+  color: #777777;
+  opacity: 0.4;
+}
+
+/* === Disabled Days === */
+.rdrDayDisabled {
+  opacity: 0.3;
+  pointer-events: none;
+}
+
+/* === Date Inputs === */
+.rdrDateDisplayWrapper {
+  background-color: transparent;
+  border-bottom: 1px solid #285E61;
+  color: #ffffff;
+}
+
+.rdrDateInput {
+  color: #ffffff;
+  background: transparent;
+  border: 1px solid #285E61;
+  border-radius: 6px;
+  padding: 6px 10px;
+}

--- a/PBL1/Spendly-Project/frontend/src/features/Transaction/TransactionList.jsx
+++ b/PBL1/Spendly-Project/frontend/src/features/Transaction/TransactionList.jsx
@@ -1,0 +1,153 @@
+import { useState, useEffect } from "react";
+
+import styles from "./TransactionList.module.css";
+import Calender from "./Calender";
+import Expense from "../../components/Data/Expense";
+import filterByDateRange from "../Filter/filter";
+
+function TransactionList() {
+  const [calender, setCalender] = useState(false);
+  const [startDate, setStartDate] = useState(null);
+  const [endDate, setEndDate] = useState(null);
+  const [currentPage, setCurrentPage] = useState(1);
+  const itemPerPage = 7;
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [startDate, endDate]);
+
+  //paginate data
+  const indexOfLastItem = currentPage * itemPerPage;
+  const indexOfFirstItem = indexOfLastItem - itemPerPage;
+
+  const filteredExpense = filterByDateRange(Expense, startDate, endDate);
+  const currentExpense = filteredExpense.slice(
+    indexOfFirstItem,
+    indexOfLastItem
+  );
+
+  console.log("Current page:", currentPage);
+  console.log("Current items:", currentExpense);
+
+  function isCalender() {
+    setCalender(!calender);
+    return calender;
+  }
+
+  return (
+    <>
+      <div className={styles.container}>
+        <div className={styles.row}>
+          <div className={styles.filterContainer}>
+            <select
+              className={styles.categoryOption}
+              name="transaction-category"
+              id="category"
+            >
+              <option value="category" selected>
+                Category
+              </option>
+              <option value="Food">Food</option>
+              <option value="Health">Health</option>
+              <option value="Personal Care">Personal Care</option>
+              <option value="Gym">Gym</option>
+              <option value="Miscelleneous">Miscelleneous</option>
+              <option value="Study">Study</option>
+              <option value="Home Appliance">Home Appliance</option>
+              <option value="Petrol">Petrol</option>
+              <option value="Grocery">Grocery</option>
+            </select>
+
+            <button
+              className={styles.calenderBtn}
+              onClick={() => isCalender(!calender)}
+            >
+              Date
+            </button>
+            {calender && (
+              <Calender
+                onRangeChange={(start, end) => {
+                  setStartDate(start);
+                  setEndDate(end);
+                }}
+              />
+            )}
+
+            <select
+              className={styles.expenseType}
+              name="type"
+              id="expense-type"
+            >
+              <option value="Type" Selected>
+                Type
+              </option>
+              <option value="Expense">Expense</option>
+              <option value="Income">Income</option>
+            </select>
+          </div>
+
+          <div className={styles.paginationContainer}>
+            <input
+              className={styles.prevBtn}
+              type="button"
+              value={"<"}
+              onClick={() => setCurrentPage((prev) => Math.max(prev - 1, 1))}
+              disabled={currentPage === 1}
+            />
+            <span>{currentPage}</span>
+            <input
+              className={styles.nextBtn}
+              type="button"
+              value={">"}
+              onClick={() =>
+                setCurrentPage((prev) =>
+                  prev < Math.ceil(filteredExpense.length / itemPerPage)
+                    ? prev + 1
+                    : prev
+                )
+              }
+              disabled={
+                currentPage === Math.ceil(filteredExpense.length / itemPerPage)
+              }
+            />
+          </div>
+        </div>
+
+        <div className={styles.ListContainer}>
+          <ul className={styles.expenselist}>
+            {currentExpense.map((expense, index) => {
+              return (
+                <li key={index} className={styles.expenseItem}>
+                  <div class={styles.expenseDetail}>
+                    <div className={styles.right}>
+                      <h3 className={styles.expenseCategory}>
+                        {expense.category}
+                      </h3>
+                      <p className={styles.expenseDescription}>
+                        {expense.description}
+                      </p>
+                    </div>
+                    <div className={styles.mid}>
+                      $
+                      <strong className={styles.expenseAmount}>
+                        {expense.amount}
+                      </strong>
+                      <p className={styles.expenseDate}>{expense.date}</p>
+                    </div>
+
+                    <div className={styles.expenseAction}>
+                      <button className={styles.editButton}>Edit</button>
+                      <button className={styles.deleteButton}>Delete</button>
+                    </div>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default TransactionList;

--- a/PBL1/Spendly-Project/frontend/src/features/Transaction/TransactionList.module.css
+++ b/PBL1/Spendly-Project/frontend/src/features/Transaction/TransactionList.module.css
@@ -1,0 +1,166 @@
+@import url("https://fonts.googleapis.com/css2?family=Irish+Grover&family=Noto+Sans:ital,wght@0,100..900;1,100..900&family=Roboto:ital,wght@0,100..900;1,100..900&family=Source+Sans+3:ital,wght@0,200..900;1,200..900&family=VT323&display=swap");
+
+.container {
+  font-family: "Source Sans 3", sans-serif;
+  margin: 50px 14rem;
+  width: 80vw;
+  height: 80vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.filterContainer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 1rem;
+  margin-bottom: 6px;
+}
+
+.ListContainer {
+  /* margin: 50px 14rem; */
+  width: 80vw;
+  height: 80vh;
+  background-color: #152f29;
+  font-size: 18px;
+  display: flex;
+  flex-direction: column;
+  border-radius: 2%;
+}
+
+.calenderBtn {
+  color: #ffffff;
+  font-family: "Source Sans 3", sans-serif;
+  font-size: 16px;
+  padding: 6px 12px;
+  background-color: #1c4a3f;
+  border: none;
+  border-radius: 8%;
+  cursor: pointer;
+}
+
+.categoryOption {
+  color: #ffffff;
+  width: 100px;
+  font-family: "Source Sans 3", sans-serif;
+  font-size: 16px;
+  padding: 6px 12px;
+  text-align: center;
+  cursor: pointer;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border: none;
+  border-radius: 8%;
+  background-color: #1c4a3f;
+  outline: none;
+}
+
+.expenseType {
+  font-family: "Source Sans 3", sans-serif;
+  color: #ffff;
+  font-size: 16px;
+  padding: 6px 4px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border: none;
+  border-radius: 8%;
+  text-align: center;
+  background-color: #1c4a3f;
+  cursor: pointer;
+}
+
+.expenselist {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.expenseItem {
+  color: #ffffff;
+  /* display: flex;
+  align-items: center;
+  justify-content: space-between; */
+  padding: 0.5rem;
+  margin: 0.5rem;
+  background: #1c4a3f;
+  border-radius: 8px;
+  transition: transform 0.2s ease;
+  text-align: center;
+}
+
+.expenseItem:hover{
+  border-bottom: 1px solid #002218;
+  transform: translateY(-2px);
+}
+
+.expenseDetail {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 10px;
+  border-radius: 8px;
+  flex-wrap: wrap;
+}
+
+
+.expenseAction {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.editButton,
+.deleteButton {
+  border: none;
+  padding: 6px 12px;
+  border-radius: 6px;
+  font-family: "Source Sans 3", sans-serif;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.editButton{
+  color: #002218;
+}
+
+.deleteButton{
+  color: #ffffff;
+  background-color: #002218;
+}
+
+.row{
+  display: flex;
+  text-align: center;
+  align-items: center;
+  justify-content: space-between;
+}
+
+
+.paginationContainer{
+  margin: 0;
+  padding: 5px;
+}
+
+span{
+  color: #ffffff;
+  margin: 0px 6px;
+}
+
+.prevBtn, .nextBtn{
+  padding: 2px 5px;
+  font-size: 16px;
+  font-weight: bolder;
+  border: none;
+  background-color: transparent;
+  color: #ffffff;
+  cursor: pointer;
+}
+
+.prevBtn:disabled,
+.nextBtn:disabled {
+  background-color: #002218;
+  cursor: not-allowed;
+}


### PR DESCRIPTION
## Summary

Added a feature to list out the transaction and  filter expense transactions by date range and paginate the transaction list for better UX on Spendly.

## Changes Made

- Integrated a date range picker to filter expenses.
- Implemented pagination logic in `TransactionList.jsx` to show 7 expenses per page.
- Added `useEffect` to reset to page 1 when filters change.
- created filter.jsx, Calender.jsx, expense.js for dummy data
- Minor styling updates to `TransactionList.module.css`.

## Testing Plan

1. Navigate to `/transactions` page or root path.
2. Select a start and end date using the calendar component.
3. Verify that only transactions within that date range are displayed.
4.  Click on pagination controls to switch pages which is located in top of the list on right side.
5. Ensure page resets to 1 on changing date range.

## Screenshots

![Date Range Filter](<img width="2107" height="846" alt="image" src="https://github.com/user-attachments/assets/62ecae14-cf08-4cf1-8a66-bb41fff18a15" />)  
*Filtered transactions by date range*

![List](<img width="2549" height="1364" alt="Screenshot 2025-08-04 164408" src="https://github.com/user-attachments/assets/05806532-b4a6-441f-bb6d-c3bd01c73a3f" />)  
*Transaction list*

