### PR TITLE
Expand MCP Web Search to Support Non-Stripe Queries, Rich Summaries, Sources, and Cache Bypass

### DIFF
--- a/PBL4/StripeCustomerSupportAgent/Backend/services/queryClassifier.js
+++ b/PBL4/StripeCustomerSupportAgent/Backend/services/queryClassifier.js
@@ -77,8 +77,8 @@ class QueryClassifier {
             * Requests to remember something (e.g., "remember my name is X")
             * Questions like "who am I", "what did I say", "what did you tell me"
           
-          - Use MCP_TOOLS_ONLY for: calculations, status checks, real-time data, specific tool operations
-          - Use HYBRID_SEARCH for: API documentation, implementation guides, general Stripe concepts
+          - Use MCP_TOOLS_ONLY for: calculations, status checks, real-time data, specific tool operations, and ANY non-Stripe general knowledge or current events/news queries (e.g., Israel-Palestine, Russia-Ukraine, weather today). Prefer the web_search tool in these cases.
+          - Use HYBRID_SEARCH for: API documentation, implementation guides, general Stripe concepts ONLY
           - Use COMBINED for: complex queries that need both real-time data and documentation
 
           CRITICAL: If the query is conversational (asking about personal info, previous conversation, etc.), 


### PR DESCRIPTION
### Summary
This PR generalizes the MCP web_search tool to handle non‑Stripe queries (e.g., current events), enhances the response format to include multi‑bullet summaries and source links, and adds a cache bypass so users can force a fresh fetch.

### Key Changes
- Generalized web search:
    Detects Stripe vs non‑Stripe queries; adjusts filters, relevance, and scoring accordingly.
    Non‑Stripe queries no longer restrict to Stripe domains.
- Richer outputs for MCP-only answers:
    For web_search, generate 3–6 concise bullets and a “Sources” list with direct links.
- Routing updates:
    Non‑Stripe queries are forced to MCP-only (skip hybrid search over Stripe docs).
