### PR TITLE
bug/fix: atomic multi-seat Redis locking with rollback to prevent par…

### DIFF
--- a/PBL5/1_MovieTicketBookingSystem/backend/utils/redisLock.js
+++ b/PBL5/1_MovieTicketBookingSystem/backend/utils/redisLock.js
@@ -35,11 +35,7 @@ async function acquireLock(key, ttlSeconds = 300) {
       EX: ttlSeconds, // Expire after TTL seconds
     });
 
-    if (result === "OK") {
-      return lockToken; // Lock acquired
-    }
-
-    return null; // Lock already held by another process
+    return result === "OK" ? lockToken : null;
   } catch (error) {
     // If Redis fails, log warning but don't block (graceful degradation)
     console.warn(`Failed to acquire lock for ${key}:`, error.message);
@@ -80,35 +76,95 @@ async function releaseLock(key, lockToken) {
 }
 
 /**
- * Acquire locks for multiple seats atomically
+ * Atomic multi-seat locking using a single Lua Script
+ * All locks are acquired atomically - either all succeed or all fail
  * Uses a "try all, release all on failure" approach
  * @param {Array<string>} seatKeys - Array of lock keys (e.g., ['seat:123:showtime:456', ...])
  * @param {number} ttlSeconds - Time to live in seconds
  * @returns {Promise<{acquired: Array<{key: string, token: string}>, failed: Array<string>}>}
  */
 async function acquireLocks(seatKeys, ttlSeconds = 300) {
-  const acquired = [];
-  const failed = [];
-
-  // Try to acquire all locks
-  for (const key of seatKeys) {
-    const token = await acquireLock(key, ttlSeconds);
-    if (token) {
-      acquired.push({ key, token });
-    } else {
-      failed.push(key);
-    }
+  if (!seatKeys || seatKeys.length === 0) {
+    return { acquired: [], failed: [] };
   }
 
-  // If any lock failed, release all acquired locks (all-or-nothing)
-  if (failed.length > 0) {
-    for (const { key, token } of acquired) {
-      await releaseLock(key, token);
-    }
-    return { acquired: [], failed };
-  }
+  const lockKeys = seatKeys.map((key) => `lock:${key}`);
+  const tokens = seatKeys.map(() => crypto.randomUUID());
 
-  return { acquired, failed: [] };
+  const luaScript = `
+    -- KEYS: lock keys
+    -- ARGV[1]: ttl (seconds)
+    -- ARGV[2..n]: tokens for each key (same index)
+
+    local ttl = tonumber(ARGV[1])
+    local tokens = {}
+    for i = 2, #ARGV do
+      tokens[i - 1] = ARGV[i]
+    end
+
+    -- Try to acquire all locks atomically
+    -- Track which ones we successfully acquire
+    local acquired = {}
+    local failed = {}
+
+    for i = 1, #KEYS do
+      local result = redis.call("SET", KEYS[i], tokens[i], "NX", "EX", ttl)
+      if result then
+        table.insert(acquired, i)
+      else
+        table.insert(failed, KEYS[i])
+      end
+    end
+
+    -- If any lock failed, release all acquired locks (rollback)
+    if #failed > 0 then
+      for _, idx in ipairs(acquired) do
+        if redis.call("GET", KEYS[idx]) == tokens[idx] then
+          redis.call("DEL", KEYS[idx])
+        end
+      end
+      return {0, unpack(failed)}
+    end
+
+    -- All locks acquired successfully
+    return {1}
+  `;
+
+  const args = [ttlSeconds, ...tokens];
+  try {
+    const result = await redis.eval(luaScript, {
+      keys: lockKeys,
+      arguments: args,
+    });
+
+    //success case
+
+    if (result && result[0] === 1) {
+      return {
+        acquired: lockKeys.map((k, i) => ({
+          key: seatKeys[i],
+          token: tokens[i],
+        })),
+        failed: [],
+      };
+    }
+
+    //failure case
+    const failedKeys =
+      result && result.length > 1
+        ? result.slice(1).map((x) => x.replace("lock:", ""))
+        : seatKeys;
+    return {
+      acquired: [],
+      failed: failedKeys,
+    };
+  } catch (error) {
+    console.warn(`Failed to acquire locks:`, error.message);
+    return {
+      acquired: [],
+      failed: seatKeys,
+    };
+  }
 }
 
 /**
@@ -116,8 +172,32 @@ async function acquireLocks(seatKeys, ttlSeconds = 300) {
  * @param {Array<{key: string, token: string}>} locks - Array of lock objects
  */
 async function releaseLocks(locks) {
-  const promises = locks.map(({ key, token }) => releaseLock(key, token));
-  await Promise.all(promises);
+  if (!locks || locks.length === 0) {
+    return;
+  }
+  try {
+    const keys = locks.map((l) => `lock:${l.key}`);
+    const tokens = locks.map((l) => l.token);
+    const luaScript = `
+      local released = 0
+      for i = 1, #KEYS do
+        if redis.call("GET", KEYS[i]) == ARGV[i] then
+          redis.call("DEL", KEYS[i])
+          released = released + 1
+        end
+      end
+      return released
+    `;
+    const released = await redis.eval(luaScript, {
+      keys,
+      arguments: tokens,
+    });
+    if (released < locks.length) {
+      console.warn(`Released ${released} out of ${locks.length} locks`);
+    }
+  } catch (error) {
+    console.warn(`Failed to release locks:`, error.message);
+  }
 }
 
 /**


### PR DESCRIPTION
## Problems with Previous Implementation

- `acquireLocks` acquired locks **sequentially**, causing **partial locks** under high concurrency.  
- Multiple Redis **round-trips per seat**, leading to performance inefficiency.  
- Brief window of **race conditions** during rollback if some locks failed.  
- `releaseLocks` issued **separate commands per lock**, slowing down multi-seat releases.  

---

## Features / Fixes

- Introduced a **single Lua script** to acquire multiple seats atomically: **all succeed or all fail**.  
- Multi-seat **release** also handled atomically in a single Lua script.  
- **Rollback on failure**: releases all partially acquired locks if any lock cannot be acquired.  
- **Minimizes race conditions**, reduces Redis round trips, and improves performance.  
- Ensures locks are **only released by their owner** using unique tokens.

# Impact:
- Fully atomic, safer, and faster seat reservation locking for high-concurrency scenarios.

---