### PR TITLE
feat: add events list column to the right of calendar

### DIFF
--- a/tej-pbl/tej-patro/frontend/src/App.jsx
+++ b/tej-pbl/tej-patro/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import Login from "./components/Login.jsx";
 import { fetchEvents } from "./api/event.js";
 import { API_URL } from "./config/env.js";
 import Navbar from "./components/Navbar.jsx";
+import EventsList from "./components/EventsList.jsx";
 
 function App() {
   console.log("App");
@@ -73,7 +74,7 @@ function App() {
   }, [user]);
 
   return (
-    <div className="App">
+    <div className="App flex flex-col min-h-screen">
       <Navbar
         user={user}
         onLogout={handleLogout}
@@ -92,11 +93,16 @@ function App() {
       {showLogin ? (
         <Login onBack={() => setShowLogin(false)} />
       ) : (
-        <Calendar
-          current={calendarDate}
-          onDateChange={setCalendarDate}
-          events={events}
-        />
+        <div className="flex flex-1 min-h-0">
+          <div className="flex-1 min-w-0 overflow-auto">
+            <Calendar
+              current={calendarDate}
+              onDateChange={setCalendarDate}
+              events={events}
+            />
+          </div>
+          <EventsList events={events} />
+        </div>
       )}
     </div>
   );

--- a/tej-pbl/tej-patro/frontend/src/components/EventsList.jsx
+++ b/tej-pbl/tej-patro/frontend/src/components/EventsList.jsx
@@ -1,0 +1,46 @@
+function formatEventDate(dateStr) {
+  if (!dateStr) return "";
+  const d = new Date(dateStr);
+  if (Number.isNaN(d.getTime())) return dateStr;
+  return d.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function EventsList({ events = [] }) {
+  return (
+    <aside className="w-80 shrink-0 border-l border-slate-200 bg-white p-4 overflow-y-auto">
+      <h3 className="text-sm font-semibold text-slate-800 mb-3">Events</h3>
+      {events.length === 0 ? (
+        <p className="text-sm text-slate-500">No events yet.</p>
+      ) : (
+        <ul className="space-y-3">
+          {events.map((event) => (
+            <li
+              key={event._id}
+              className="rounded-lg border border-slate-200 bg-slate-50/80 p-3 text-left"
+            >
+              <p className="text-sm font-medium text-slate-800 truncate">
+                {event.title}
+              </p>
+              <p className="text-xs text-slate-500 mt-0.5">
+                {formatEventDate(event.start)} – {formatEventDate(event.end)}
+              </p>
+              {event.description && (
+                <p className="text-xs text-slate-600 mt-1 line-clamp-2">
+                  {event.description}
+                </p>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </aside>
+  );
+}
+
+export default EventsList;


### PR DESCRIPTION
Closes #768 

## Summary

## What
- Add an **events list** in a right-side column beside the calendar so users can see all events at a glance.
- Layout: calendar on the left, events list on the right (flex row).

## Why
- Events were only creatable; there was no place to view the list. The right column shows title, date/time range, and description for each event.

## Changes
- **EventsList.jsx**: New component that takes `events` and renders a list (title, formatted start–end, optional description). Shown when there are no events as "No events yet."
- **App.jsx**: 
  - App container uses `flex flex-col min-h-screen` for full-height layout.
  - When not on login, calendar and EventsList are wrapped in a `flex flex-1 min-h-0` row: calendar in a `flex-1 min-w-0` wrapper, EventsList as fixed-width right column.
  - EventsList is only rendered next to the calendar (not on login screen).

## Testing
- [x] Calendar and events list appear side by side (list on the right).
- [x] Events list shows created events with title, dates, and description.
- [x] Empty state shows "No events yet."
- [x] Login view does not show the events list.