### PR TITLE
feat: add/improve Gemini tips error handling and no-events fallback

### DIFF
--- a/tej-pbl/tej-patro/backend/src/config/gemini.js
+++ b/tej-pbl/tej-patro/backend/src/config/gemini.js
@@ -28,10 +28,23 @@ function getModel(modelName = "gemini-3-flash-preview") {
         if (!response) {
           throw new Error("Gemini returned no response");
         }
+
+        /*
+        - Checks whether the Gemini API blocked the prompt due to safety filters.
+        - The API may return `promptFeedback.blockReason` when a request violates
+          - safety policies. If a valid block reason exists (not null, empty, or
+          - "BLOCK_REASON_UNSPECIFIED"), an error is thrown so the controller can
+          - return a 422 response instead of a 500 server error.
+          
+        */
+
+        const blockReason = response.promptFeedback?.blockReason;
+        if (blockReason != null && blockReason !== "" && String(blockReason) !== "BLOCK_REASON_UNSPECIFIED") {   //// Using `!= null`: checks both `null` and `undefined` in one condition
+          throw new Error("Content was blocked by safety filter");
+        }
+        const text = response.text ?? "";
         return {
-          response: {
-            text: response.text ?? "",
-          },
+          response: { text },
         };
       } catch (error) {
         const message = error?.message ?? "Failed to generate content";

--- a/tej-pbl/tej-patro/backend/src/controllers/tipsController.js
+++ b/tej-pbl/tej-patro/backend/src/controllers/tipsController.js
@@ -27,6 +27,35 @@ Output format:
 Example:
 ["Group similar tasks to reduce context switching.","Schedule short breaks between long meetings.","Reserve a focus block for deep work."]`;
 
+/*NOTE (No events in range): 
+We still call Gemini with this message when there are no events. The system prompt tells the model to return 3 general time-management
+ tips, so the frontend always gets a valid tips array or a proper error.*/
+const NO_EVENTS_USER_MESSAGE = "I have no events in this range.";
+
+
+/**
+ * Checks if an error is caused by Gemini's safety or content filtering.
+ *
+ * Looks for keywords like "block", "safety", "filter", "content policy", or "harm"
+ * in the error message. Returns true if any are found, otherwise false.
+ */
+function isBlockOrSafetyError(err) {
+  const msg = (err?.message ?? String(err)).toLowerCase();
+  return (
+    msg.includes("block") ||
+    msg.includes("safety") ||
+    msg.includes("filter") ||
+    msg.includes("blocked") ||
+    msg.includes("content policy") ||
+    msg.includes("harm")
+  );
+}
+
+/** Ensures value is a non-empty array of strings (valid tips format). */
+function isArrayOfStrings(arr) {
+  return Array.isArray(arr) && arr.length > 0 && arr.every((item) => typeof item === "string");
+}
+
 async function getTips(req, res, next) {
   const { start, end } = req.query;
     
@@ -49,23 +78,59 @@ async function getTips(req, res, next) {
       description: e.description ?? "",
     }));
 
-    const userMessage = `Here are the calendar events:\n${JSON.stringify(eventsForPrompt)}`;
-    const fullPrompt = `${TIPS_SYSTEM_PROMPT}\n\n${userMessage}`;
-
-    const text = await generateText(fullPrompt);
-
-    let data;
-    try {
-      const parsed = JSON.parse(text.trim());
-      data = Array.isArray(parsed) ? parsed : [text];
-    } catch {
-      data = [text];
-    }
-    res.json({ data });
-  } catch (error) {
-    next(error);
-  }
+ // STATIC FALLBACK for no events:
+// If there are no events in the range, do NOT call Gemini.
+// Return a fixed set of generic productivity tips instead.
+if (eventsForPrompt.length === 0) {
+  return res.json({
+    data: [
+      "Add events in this range to get personalized tips.",
+      "Block time for focused work in your calendar.",
+      "Review your week and plan key tasks.",
+    ],
+  });
 }
+// For non-empty event lists, we still call Gemini as before.
+const userMessage = `Here are the calendar events:\n${JSON.stringify(eventsForPrompt)}`;
+const fullPrompt = `${TIPS_SYSTEM_PROMPT}\n\n${userMessage}`;    
+
+   let text;
+   try {
+     text = await generateText(fullPrompt);
+   } catch (err) {
+     // NOTE: Safety/block — return 422 with a user-friendly message so frontend can show or retry.
+     if (isBlockOrSafetyError(err)) {
+       return res.status(422).json({
+         error: "Content was filtered; try different events or dates.",
+       });
+     }
+     throw err;
+   }
+   // NOTE: Empty or missing Gemini response — do not treat as success; return 502.
+   const trimmed = text != null ? String(text).trim() : "";
+   if (!trimmed) {
+     return res.status(502).json({ error: "AI did not return insights" });
+   }
+   let data;
+   try {
+     const parsedData = JSON.parse(trimmed);
+     // NOTE: Invalid format — must be a non-empty array of strings; otherwise 502 + log for debugging.
+     if (!isArrayOfStrings(parsedData)) {
+       console.error("Invalid insights format - raw response:", trimmed);
+       return res.status(502).json({ error: "Invalid insights format" });
+     }
+     data = parsedData;
+   } catch {
+     // NOTE: JSON.parse threw; return 502 and log raw text for debugging.
+     console.error("Invalid insights format - parse error, raw response:", trimmed);
+     return res.status(502).json({ error: "Invalid insights format" });
+   }
+   res.json({ data });
+ } catch (error) {
+   next(error);
+ }
+}
+
 
 module.exports = {
   getTips,

--- a/tej-pbl/tej-patro/backend/src/requests/my_requests.rest
+++ b/tej-pbl/tej-patro/backend/src/requests/my_requests.rest
@@ -1,6 +1,6 @@
 ### Variables
 @baseUrl = http://localhost:5000
-@cookie = connect.sid=s%3Acril-t_Qza4TY1rXzT7lQoUNwI4B21xv.A8gQlLIAOY0i3H31KHEhrfCFm4a5xgRlYnpFYoXRpQs
+@cookie = connect.sid=<YOUR_COOKIE_HERE>
 
 ### Unauthenticated create event (expect 401)
 POST {{baseUrl}}/api/events
@@ -82,4 +82,45 @@ Cookie: {{cookie}}
 ### Get tips — with date  range
 // @no-cookie-jar
 GET {{baseUrl}}/api/events/tips?start=2026-02-28&end=2026-02-28
+Cookie: {{cookie}}
+
+
+### Get tips when there are NO events in the range
+// This request returns 3 static generic tips because there are no events in this date range.
+// Static fallback: does NOT call Gemini in this case.
+// @no-cookie-jar
+GET {{baseUrl}}/api/events/tips?start=2099-03-16&end=2099-03-16
+Cookie: {{cookie}}
+
+
+### Get tips with invalid date query (should hit parseListOptionsFromQuery error)
+// @no-cookie-jar
+GET {{baseUrl}}/api/events/tips?start=not-a-date&end=also-bad
+Cookie: {{cookie}}
+
+
+### Create an event with unsafe/harmful content (for safety test)
+// @no-cookie-jar
+POST {{baseUrl}}/api/events
+Content-Type: application/json
+Cookie: {{cookie}}
+
+{
+  "title": "Plan a detailed violent attack on my colleague",
+  "start": "2026-03-16T09:00:00.000Z",
+  "end": "2026-03-16T10:00:00.000Z",
+  "description": "This content should be blocked by safety filter",
+  "location": "Office",
+  "isAllDay": false,
+  "color": "#FF0000"
+}
+
+### List events including the unsafe one (optional)
+// @no-cookie-jar
+GET {{baseUrl}}/api/events?start=2026-03-16&end=2026-03-17
+Cookie: {{cookie}}
+
+### Try to trigger Gemini safety filter for tips
+// @no-cookie-jar
+GET {{baseUrl}}/api/events/tips?start=2026-03-16&end=2026-03-17
 Cookie: {{cookie}}


### PR DESCRIPTION

## Summary

- Added proper error handling around the Gemini AI call so the frontend always gets either valid tips or a clear error message.
- Added simple fallback tips when there are no events in the selected date range, avoiding unnecessary AI calls.
- Added validation to make sure only correctly formatted AI responses are accepted as valid insights.

## Changes Made

**backend/src/controllers/tipsController.js**

- Added fallback tips when there are no events so the API doesn’t call Gemini unnecessarily.
- Added helper checks to detect Gemini safety errors and verify AI output is a valid list of tips.
- Return a clear **502 error** if Gemini returns an empty or missing response.
- If Gemini returns incorrectly formatted tips, return **502 "Invalid insights format"** and log the raw response for debugging.
- Return **422 with a user-friendly message** when Gemini blocks content for safety reasons.

**backend/src/config/gemini.js**

- Added a check for Gemini safety blocks and throw a clear error if content is restricted.
- Standardized Gemini responses so controllers always receive a consistent `text` output.

**backend/src/requests/my_requests.rest**

- Added test requests for normal event ranges.
- Added requests for no-event cases to verify fallback tips.
- Added requests to test Gemini safety blocks and other error handling.


- [ ] Linked issues: Closes #798 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved content safety filtering for AI-generated tips; invalid or blocked responses are now properly caught and reported.
  * Enhanced response validation to ensure tips are returned in the correct format.

* **New Features**
  * Added fallback tips when no calendar events exist, eliminating unnecessary AI calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->