### PR TITLE
Setup routes (Home, Favorites, Auth) and add static navbar

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-    "postman.settings.dotenv-detection-notification-visibility": false
+  "postman.settings.dotenv-detection-notification-visibility": false,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "files.insertFinalNewline": true
 }

--- a/PBL2/Pustakalaya/frontend/package.json
+++ b/PBL2/Pustakalaya/frontend/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^19.2.4",
-    "react-dom": "^19.2.4"
+    "react-dom": "^19.2.4",
+    "react-router-dom": "^7.13.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/PBL2/Pustakalaya/frontend/package.json
+++ b/PBL2/Pustakalaya/frontend/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "lucide-react": "^0.577.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-router-dom": "^7.13.1"

--- a/PBL2/Pustakalaya/frontend/src/App.jsx
+++ b/PBL2/Pustakalaya/frontend/src/App.jsx
@@ -1,17 +1,19 @@
 import { Routes, Route } from 'react-router-dom';
+import MainLayout from './layout/MainLayout';
 import Home from './pages/Home';
 import Auth from './pages/Auth';
+import Favorites from './pages/Favorites';
 
 const App = () => {
-
   return (
-    <>
-      <Routes>
+    <Routes>
+      <Route element={<MainLayout />}>
         <Route path="/" element={<Home />} />
-        <Route path="/auth" element={<Auth />} />
-      </Routes>
-    </>
-  )
-}
+        <Route path="/favorites" element={<Favorites />} />
+      </Route>
+      <Route path="/auth" element={<Auth />} />
+    </Routes>
+  );
+};
 
-export default App
+export default App;

--- a/PBL2/Pustakalaya/frontend/src/App.jsx
+++ b/PBL2/Pustakalaya/frontend/src/App.jsx
@@ -1,8 +1,8 @@
-import { Routes, Route } from 'react-router-dom';
-import MainLayout from './layout/MainLayout';
-import Home from './pages/Home';
-import Auth from './pages/Auth';
-import Favorites from './pages/Favorites';
+import { Routes, Route } from "react-router-dom";
+import MainLayout from "./layout/MainLayout";
+import Home from "./pages/Home";
+import Auth from "./pages/Auth";
+import Favorites from "./pages/Favorites";
 
 const App = () => {
   return (

--- a/PBL2/Pustakalaya/frontend/src/App.jsx
+++ b/PBL2/Pustakalaya/frontend/src/App.jsx
@@ -1,11 +1,15 @@
+import { Routes, Route } from 'react-router-dom';
+import Home from './pages/Home';
+import Auth from './pages/Auth';
 
-function App() {
+const App = () => {
 
   return (
     <>
-      <h1 className="text-3xl font-bold">
-      Hello world!
-    </h1>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/auth" element={<Auth />} />
+      </Routes>
     </>
   )
 }

--- a/PBL2/Pustakalaya/frontend/src/components/Navbar.jsx
+++ b/PBL2/Pustakalaya/frontend/src/components/Navbar.jsx
@@ -1,0 +1,58 @@
+import { Link, NavLink } from 'react-router-dom';
+import { Home, Heart, Moon, User } from 'lucide-react';
+
+const Navbar = () => {
+    const linkClass = ({ isActive }) =>
+        `flex items-center gap-2 rounded-full px-4 py-2 transition-colors ${
+          isActive
+            ? 'bg-active-bg text-gray-900 shadow-sm'
+            : 'text-gray-700 hover:text-gray-900 hover:bg-black/5'
+        }`;
+
+    return (
+        <header className="sticky top-0 z-50 bg-cream/90 backdrop-blur supports-[backdrop-filter]:bg-cream/75">
+          <nav className="border-b border-black/5">
+            <div className="max-w-7xl mx-auto px-6 py-4 flex items-center justify-between">
+              <Link
+                to="/"
+                className="font-serif font-extrabold text-2xl tracking-tight text-black hover:opacity-90"
+              >
+                <span className="text-terracotta">TEJ</span> Pustakalaya
+              </Link>
+    
+              <div className="flex items-center gap-3">
+                <NavLink to="/" className={linkClass} end>
+                  <Home size={18} strokeWidth={1.75} />
+                  <span className="text-sm font-medium">Home</span>
+                </NavLink>
+    
+                <NavLink to="/favorites" className={linkClass}>
+                  <Heart size={18} strokeWidth={1.75} />
+                  <span className="text-sm font-medium">Favorites</span>
+                </NavLink>
+              </div>
+    
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  aria-label="Toggle dark mode"
+                  className="p-2 rounded-full text-gray-700 hover:text-gray-900 hover:bg-black/5 transition-colors"
+                >
+                  <Moon size={18} strokeWidth={1.75} />
+                </button>
+    
+                <button
+                  type="button"
+                  aria-label="Profile"
+                  className="p-2 rounded-full text-terracotta hover:bg-terracotta/10 transition-colors"
+                >
+                  <User size={18} strokeWidth={1.75} />
+                </button>
+              </div>
+            </div>
+          </nav>
+        </header>
+      );
+};
+
+export default Navbar;

--- a/PBL2/Pustakalaya/frontend/src/components/Navbar.jsx
+++ b/PBL2/Pustakalaya/frontend/src/components/Navbar.jsx
@@ -1,58 +1,58 @@
-import { Link, NavLink } from 'react-router-dom';
-import { Home, Heart, Moon, User } from 'lucide-react';
+import { Link, NavLink } from "react-router-dom";
+import { Home, Heart, Moon, User } from "lucide-react";
 
 const Navbar = () => {
-    const linkClass = ({ isActive }) =>
-        `flex items-center gap-2 rounded-full px-4 py-2 transition-colors ${
-          isActive
-            ? 'bg-active-bg text-gray-900 shadow-sm'
-            : 'text-gray-700 hover:text-gray-900 hover:bg-black/5'
-        }`;
+  const linkClass = ({ isActive }) =>
+    `flex items-center gap-2 rounded-full px-4 py-2 transition-colors ${
+      isActive
+        ? "bg-active-bg text-gray-900 shadow-sm"
+        : "text-gray-700 hover:text-gray-900 hover:bg-black/5"
+    }`;
 
-    return (
-        <header className="sticky top-0 z-50 bg-cream/90 backdrop-blur supports-[backdrop-filter]:bg-cream/75">
-          <nav className="border-b border-black/5">
-            <div className="max-w-7xl mx-auto px-6 py-4 flex items-center justify-between">
-              <Link
-                to="/"
-                className="font-serif font-extrabold text-2xl tracking-tight text-black hover:opacity-90"
-              >
-                <span className="text-terracotta">TEJ</span> Pustakalaya
-              </Link>
-    
-              <div className="flex items-center gap-3">
-                <NavLink to="/" className={linkClass} end>
-                  <Home size={18} strokeWidth={1.75} />
-                  <span className="text-sm font-medium">Home</span>
-                </NavLink>
-    
-                <NavLink to="/favorites" className={linkClass}>
-                  <Heart size={18} strokeWidth={1.75} />
-                  <span className="text-sm font-medium">Favorites</span>
-                </NavLink>
-              </div>
-    
-              <div className="flex items-center gap-2">
-                <button
-                  type="button"
-                  aria-label="Toggle dark mode"
-                  className="p-2 rounded-full text-gray-700 hover:text-gray-900 hover:bg-black/5 transition-colors"
-                >
-                  <Moon size={18} strokeWidth={1.75} />
-                </button>
-    
-                <button
-                  type="button"
-                  aria-label="Profile"
-                  className="p-2 rounded-full text-terracotta hover:bg-terracotta/10 transition-colors"
-                >
-                  <User size={18} strokeWidth={1.75} />
-                </button>
-              </div>
-            </div>
-          </nav>
-        </header>
-      );
+  return (
+    <header className="sticky top-0 z-50 bg-cream/90 backdrop-blur supports-[backdrop-filter]:bg-cream/75">
+      <nav className="border-b border-black/5">
+        <div className="max-w-7xl mx-auto px-6 py-4 flex items-center justify-between">
+          <Link
+            to="/"
+            className="font-serif font-extrabold text-2xl tracking-tight text-black hover:opacity-90"
+          >
+            <span className="text-terracotta">TEJ</span> Pustakalaya
+          </Link>
+
+          <div className="flex items-center gap-3">
+            <NavLink to="/" className={linkClass} end>
+              <Home size={18} strokeWidth={1.75} />
+              <span className="text-sm font-medium">Home</span>
+            </NavLink>
+
+            <NavLink to="/favorites" className={linkClass}>
+              <Heart size={18} strokeWidth={1.75} />
+              <span className="text-sm font-medium">Favorites</span>
+            </NavLink>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              aria-label="Toggle dark mode"
+              className="p-2 rounded-full text-gray-700 hover:text-gray-900 hover:bg-black/5 transition-colors"
+            >
+              <Moon size={18} strokeWidth={1.75} />
+            </button>
+
+            <button
+              type="button"
+              aria-label="Profile"
+              className="p-2 rounded-full text-terracotta hover:bg-terracotta/10 transition-colors"
+            >
+              <User size={18} strokeWidth={1.75} />
+            </button>
+          </div>
+        </div>
+      </nav>
+    </header>
+  );
 };
 
 export default Navbar;

--- a/PBL2/Pustakalaya/frontend/src/layout/MainLayout.jsx
+++ b/PBL2/Pustakalaya/frontend/src/layout/MainLayout.jsx
@@ -1,5 +1,5 @@
-import { Outlet } from 'react-router-dom';
-import Navbar from '../components/Navbar';
+import { Outlet } from "react-router-dom";
+import Navbar from "../components/Navbar";
 
 const MainLayout = () => {
   return (

--- a/PBL2/Pustakalaya/frontend/src/layout/MainLayout.jsx
+++ b/PBL2/Pustakalaya/frontend/src/layout/MainLayout.jsx
@@ -1,0 +1,15 @@
+import { Outlet } from 'react-router-dom';
+import Navbar from '../components/Navbar';
+
+const MainLayout = () => {
+  return (
+    <div className="min-h-screen bg-cream">
+      <Navbar />
+      <main className="w-full max-w-7xl mx-auto px-4 sm:px-6 py-8">
+        <Outlet />
+      </main>
+    </div>
+  );
+};
+
+export default MainLayout;

--- a/PBL2/Pustakalaya/frontend/src/main.jsx
+++ b/PBL2/Pustakalaya/frontend/src/main.jsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>,
 )

--- a/PBL2/Pustakalaya/frontend/src/main.jsx
+++ b/PBL2/Pustakalaya/frontend/src/main.jsx
@@ -1,13 +1,13 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import { BrowserRouter } from 'react-router-dom'
-import './index.css'
-import App from './App.jsx'
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
+import "./index.css";
+import App from "./App.jsx";
 
-createRoot(document.getElementById('root')).render(
+createRoot(document.getElementById("root")).render(
   <StrictMode>
     <BrowserRouter>
       <App />
     </BrowserRouter>
   </StrictMode>,
-)
+);

--- a/PBL2/Pustakalaya/frontend/src/pages/Auth.jsx
+++ b/PBL2/Pustakalaya/frontend/src/pages/Auth.jsx
@@ -1,0 +1,9 @@
+const Auth = () => {
+    return (
+        <div>
+            <h1>Auth Page</h1>
+        </div>
+    )
+}
+
+export default Auth;

--- a/PBL2/Pustakalaya/frontend/src/pages/Favorites.jsx
+++ b/PBL2/Pustakalaya/frontend/src/pages/Favorites.jsx
@@ -1,6 +1,6 @@
 const Favorites = () => {
-    return (
-        <div className="py-8">
+  return (
+    <div className="py-8">
       <h1>My Favorites</h1>
     </div>
   );

--- a/PBL2/Pustakalaya/frontend/src/pages/Favorites.jsx
+++ b/PBL2/Pustakalaya/frontend/src/pages/Favorites.jsx
@@ -1,0 +1,9 @@
+const Favorites = () => {
+    return (
+        <div className="py-8">
+      <h1>My Favorites</h1>
+    </div>
+  );
+};
+
+export default Favorites;

--- a/PBL2/Pustakalaya/frontend/src/pages/Home.jsx
+++ b/PBL2/Pustakalaya/frontend/src/pages/Home.jsx
@@ -1,0 +1,9 @@
+const Home = () => {
+    return (
+        <div>
+            <h1>Home Page</h1>
+        </div>
+    )
+}
+
+export default Home;

--- a/PBL2/Pustakalaya/frontend/src/pages/Home.jsx
+++ b/PBL2/Pustakalaya/frontend/src/pages/Home.jsx
@@ -1,11 +1,11 @@
 const Home = () => {
-    return (
-        <div>
-            <h1 className="font-serif font-bold text-2xl text-gray-900 mb-4 text-center">
+  return (
+    <div>
+      <h1 className="font-serif font-bold text-2xl text-gray-900 mb-4 text-center">
         Welcome to TEJ Pustakalaya
       </h1>
-        </div>
-    )
-}
+    </div>
+  );
+};
 
 export default Home;

--- a/PBL2/Pustakalaya/frontend/src/pages/Home.jsx
+++ b/PBL2/Pustakalaya/frontend/src/pages/Home.jsx
@@ -1,7 +1,9 @@
 const Home = () => {
     return (
         <div>
-            <h1>Home Page</h1>
+            <h1 className="font-serif font-bold text-2xl text-gray-900 mb-4 text-center">
+        Welcome to TEJ Pustakalaya
+      </h1>
         </div>
     )
 }

--- a/PBL2/Pustakalaya/frontend/tailwind.config.js
+++ b/PBL2/Pustakalaya/frontend/tailwind.config.js
@@ -1,19 +1,17 @@
 /** @type {import('tailwindcss').Config} */
 export default {
-  content: ["./index.html",
-    "./src/**/*.{js,ts,jsx,tsx}",],
+  content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
     extend: {
       colors: {
-      cream: '#FCF8F4',
-      terracotta: '#A0522D',
-      'active-bg': '#E8E4E0',
+        cream: "#FCF8F4",
+        terracotta: "#A0522D",
+        "active-bg": "#E8E4E0",
+      },
+      fontFamily: {
+        serif: ["Georgia", "Cambria", "Times New Roman", "serif"],
+      },
     },
-    fontFamily: {
-      serif: ['Georgia', 'Cambria', 'Times New Roman', 'serif'],
-    },
-  },
   },
   plugins: [],
-}
-
+};

--- a/PBL2/Pustakalaya/frontend/tailwind.config.js
+++ b/PBL2/Pustakalaya/frontend/tailwind.config.js
@@ -3,7 +3,16 @@ export default {
   content: ["./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+      cream: '#FCF8F4',
+      terracotta: '#A0522D',
+      'active-bg': '#E8E4E0',
+    },
+    fontFamily: {
+      serif: ['Georgia', 'Cambria', 'Times New Roman', 'serif'],
+    },
+  },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Summary

- Adds initial Pustakalaya frontend shell with shared layout and main routes.
- MainLayout wraps all main pages with Navbar and a centered content area; Auth is outside the layout.
- Navbar provides sticky header with logo, Home and Favorites links (with active state), and placeholder dark-mode and profile buttons.
- Home shows welcome heading; Favorites and Auth are placeholder pages.

## Changes Made

- Introduces MainLayout and Navbar for the app shell.
- Registers routes: / (Home), /favorites (Favorites), /auth (Auth).
- Keeps /auth separate from the main layout for future auth flow.

## Testing Plan

1. Opened / and /favorites and confirmed layout and Navbar.
2. Confirmed /auth loads without main layout.
3. Checked NavLink active state on Home and Favorites.

## Screen-recording
[Screencast from 18-3-26 09:16:58 अपराह्न +0545.webm](https://github.com/user-attachments/assets/95bc44e0-fb9a-4a59-baaa-57097b6740d6)



- Linked issues: Closes #809 #808 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced multi-page navigation system with routing
  * Added navigation bar with Home and Favorites links, dark mode toggle, and profile menu
  * New Home page with welcome message
  * New Favorites page for bookmarked content
  * Added authentication page

* **Style**
  * Updated visual theme with new color palette and typography options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->