### PR TITLE
Pustak 805 single rout

### DIFF
--- a/PBL2/Pustakalaya/backend/index.js
+++ b/PBL2/Pustakalaya/backend/index.js
@@ -44,6 +44,28 @@ app.get("/api/books", async (req, res) => {
     res.status(500).json({ error: err.message });
   }
 });
+/* - GET endpoint to get a book by ID */
+/* - Params:
+  - id (required):string = Google Books ID (e.g. "U69Hzz2jLPUC")
+*/
+app.get("/api/books/:id", async (req, res) => {
+  try {
+    const { id } = req.params;
+    if (!id) {
+      return res.status(400).json({ error: "Book ID is required!" });
+    }
+    const response = await fetch(
+      `https://www.googleapis.com/books/v1/volumes/${id}?key=${process.env.GOOGLE_BOOKS_API_KEY}`,
+    );
+    const data = await response.json();
+    if (!data) {
+      return res.status(404).json({ message: "Book not found" });
+    }
+    res.json(data);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
 
 const PORT = process.env.PORT || 1000;
 app.listen(PORT, () =>

--- a/PBL2/Pustakalaya/backend/requests/request_api.rest
+++ b/PBL2/Pustakalaya/backend/requests/request_api.rest
@@ -6,3 +6,12 @@ GET {{baseUrl}}/api/books?q=javascript&startIndex=0
 
 ### GET /api/books — missing q (expect 400 and error message)
 GET {{baseUrl}}/api/books
+
+### GET /api/books/:id — with valid ID (expect 200 and JSON with book data)
+GET {{baseUrl}}/api/books/U69Hzz2jLPUC
+
+### GET /api/books/:id — with invalid ID (expect 400 and error message)
+GET {{baseUrl}}/api/books/123
+
+### GET /api/books/:id — missing ID (expect 400 and error message)
+GET {{baseUrl}}/api/books/


### PR DESCRIPTION
Closes #805 

## Summary

Added a new backend endpoint GET /api/books/:id to fetch a single book from the Google Books API by volume ID, and updated the REST client file with test calls for both valid/invalid IDs.

## Changes Made

- Implemented GET /api/books/:id in PBL2/Pustakalaya/backend/index.js (proxies Google Books “volumes/{id}”).
- Kept existing GET /api/books search endpoint with query validation (q required).
- Updated PBL2/Pustakalaya/backend/requests/request_api.rest with examples for:
   - GET /api/books?q=...&startIndex=...
   - GET /api/books (missing q)
   - GET /api/books/:id (valid + invalid + missing ID).
- Added inline comments in index.js to document the expected params.

## Testing Plan

- Start backend:
   - cd PBL2/Pustakalaya/backend
   - npm run dev
- Test search:
  - Open browser/REST client: http://localhost:1000/api/books?q=javascript&startIndex=0
- Test single book by ID:
  - Open browser/REST client: http://localhost:1000/api/books/U69Hzz2jLPUC
- Test invalid/missing inputs:
  - http://localhost:1000/api/books/123
  - http://localhost:1000/api/books/ (missing ID)

## Screenshots

- N/A (backend/API changes only)

## Checklist

- [x] Code is properly formatted and linted
- [x] No console.log or debugging code left in
- [x] Feature works as expected
- [x] Linked issues: Closes #

## Additional Notes

- Uses Node’s built-in fetch (requires Node 18+).
- Requires GOOGLE_BOOKS_API_KEY to be present in PBL2/Pustakalaya/backend/.env.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new endpoint to retrieve individual book details by ID. The endpoint validates input parameters and returns appropriate HTTP status codes for various scenarios including missing or invalid IDs, books not found, and server errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->