### PR TITLE
Pustak 803 mongo db

### DIFF
--- a/PBL2/Pustakalaya/backend/index.js
+++ b/PBL2/Pustakalaya/backend/index.js
@@ -4,6 +4,7 @@ const express = require("express");
   - (allows requests from other origins like your React frontend)
 */
 const cors = require("cors");
+const mongoose = require("mongoose");
 /*- Imports environment variables from a .env file */
 require("dotenv").config();
 /* - Creates the Express app instance (app)*/
@@ -68,6 +69,18 @@ app.get("/api/books/:id", async (req, res) => {
 });
 
 const PORT = process.env.PORT || 1000;
-app.listen(PORT, () =>
-  console.log(`Pustakalaya server is running on port ${PORT}`),
-);
+
+async function connectDB() {
+  try {
+    await mongoose.connect(process.env.MONGO_URI);
+    console.log("MongoDB connected");
+    app.listen(PORT, () =>
+      console.log(`Pustakalaya server is running on port ${PORT}`),
+    );
+  } catch (error) {
+    /* - Standard error log: log the error */
+    console.log("❌ MongoDB connection error: ", error.message);
+    process.exit(1);
+  }
+}
+connectDB();

--- a/PBL2/Pustakalaya/backend/index.js
+++ b/PBL2/Pustakalaya/backend/index.js
@@ -5,6 +5,7 @@ const express = require("express");
 */
 const cors = require("cors");
 const mongoose = require("mongoose");
+const User = require("./models/User");
 /*- Imports environment variables from a .env file */
 require("dotenv").config();
 /* - Creates the Express app instance (app)*/
@@ -74,6 +75,20 @@ async function connectDB() {
   try {
     await mongoose.connect(process.env.MONGO_URI);
     console.log("MongoDB connected");
+    try {
+      await User.create({
+        username: "test-user",
+        email: "test123@gmail.com",
+        password: "test123",
+      });
+      console.log("Dummy user created successfully");
+    } catch (e) {
+      if (e.code === 11000) {
+        console.log("Dummy user already exists");
+      } else {
+        console.log("Error creating dummy user", e.message);
+      }
+    }
     app.listen(PORT, () =>
       console.log(`Pustakalaya server is running on port ${PORT}`),
     );

--- a/PBL2/Pustakalaya/backend/models/User.js
+++ b/PBL2/Pustakalaya/backend/models/User.js
@@ -1,0 +1,31 @@
+const mongoose = require("mongoose");
+const userSchema = new mongoose.Schema(
+  {
+    username: {
+      type: String,
+      required: true,
+      unique: true,
+      trim: true,
+      minlength: 3,
+      maxlength: 30,
+    },
+    email: {
+      type: String,
+      required: true,
+      unique: true,
+      trim: true,
+      lowercase: true,
+    },
+    password: {
+      type: String,
+      required: true,
+      minlength: 6,
+    },
+  },
+  {
+    timestamps: true,
+  },
+);
+
+const User = mongoose.model("User", userSchema);
+module.exports = User;

--- a/PBL2/Pustakalaya/backend/package.json
+++ b/PBL2/Pustakalaya/backend/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "cors": "^2.8.6",
     "dotenv": "^17.3.1",
-    "express": "^5.2.1"
+    "express": "^5.2.1",
+    "mongoose": "^9.3.1"
   }
 }


### PR DESCRIPTION
Closes #803 
Closes #816 

## Summary

Add MongoDB connection to the Pustakalaya backend and introduce a User model with a dummy user seeded on startup so the DB connection and User schema can be verified. No auth or new API routes in this PR.

## Changes Made

- Connect to MongoDB on server startup via Mongoose using process.env.MONGO_URI; log success and exit on connection failure.
- Add models/User.js with User schema (e.g. username, email, password; required/unique/timestamps as needed).
- Require the User model in index.js and, after a successful DB connection, create and save one dummy user inside a try/catch so duplicate or other errors are logged and the server still starts.
- Rely on existing .env for MONGO_URI; ensure .env remains in .gitignore.
- Keep existing books routes (GET /api/books, GET /api/books/:id) unchanged and working.

## Testing Plan

<!-- Describe how to manually test the changes -->

- Set MONGO_URI in backend .env (local or Atlas). Run npm run dev and confirm logs: "MongoDB connected" and either "Dummy user created" (first run) or "Dummy user already exists" (subsequent runs).
- Open the database (Compass or Atlas) and confirm the users collection has one document with the dummy user’s username, email, and password.
- Call GET /api/books?q=javascript&startIndex=0 and GET /api/books/<valid-id> and confirm 200 and correct JSON (no regression).

## Screenshots

<!-- Include relevant screenshots for UI changes -->
- N/A — backend only; no UI changes.
## Checklist

- [ ] Code is properly formatted and linted
- [ ] No console.log or debugging code left in
- [ ] Feature works as expected
- [ ] Linked issues: Closes #

## Additional Notes

<!-- Any other relevant information -->
- Dummy user password is stored in plain text for this verification step only; hashing will be added when implementing auth.
- Duplicate key (11000) on rerun is handled so the server does not crash.