### PR TITLE
feat: add book listing UI on home page

### DIFF
--- a/PBL2/Pustakalaya/frontend/src/components/BookCard.jsx
+++ b/PBL2/Pustakalaya/frontend/src/components/BookCard.jsx
@@ -1,0 +1,43 @@
+// src/components/BookCard.jsx
+import { Heart } from "lucide-react";
+
+const BookCard = ({ book }) => {
+  return (
+    <div className="overflow-hidden rounded-2xl bg-white shadow-md hover:shadow-lg transition">
+      {/* Cover area */}
+      <div className="relative h-64 bg-gray-200">
+        <img
+          src={book.coverImage}
+          alt={book.title}
+          className="h-full w-full object-cover"
+        />
+
+        {/* Favorite icon */}
+        <button
+          type="button"
+          //bg-white/90: white background with 90% opacity
+          className="absolute right-3 top-3 rounded-full bg-white/90 p-2 shadow"
+        >
+          <Heart
+            size={18}
+            className={
+              book.isFavorite ? "fill-red-500 text-red-500" : "text-gray-600"
+            }
+          />
+        </button>
+      </div>
+
+      {/* Text area */}
+      <div className="p-4">
+        <h3 className="text-lg font-semibold text-gray-900">{book.title}</h3>
+        <p className="text-sm text-gray-600">{book.author}</p>
+        {/* px: padding left and right, py: padding top and bottom, */}
+        <span className="mt-2 inline-block rounded-full bg-gray-100 px-3 py-1 text-xs text-gray-700">
+          {book.category}
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export default BookCard;

--- a/PBL2/Pustakalaya/frontend/src/components/BookGrid.jsx
+++ b/PBL2/Pustakalaya/frontend/src/components/BookGrid.jsx
@@ -1,0 +1,14 @@
+// src/components/BookGrid.jsx
+import BookCard from "./BookCard";
+
+const BookGrid = ({ books }) => {
+  return (
+    <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
+      {books.map((book) => (
+        <BookCard key={book.id} book={book} />
+      ))}
+    </div>
+  );
+};
+
+export default BookGrid;

--- a/PBL2/Pustakalaya/frontend/src/components/SearchBar.jsx
+++ b/PBL2/Pustakalaya/frontend/src/components/SearchBar.jsx
@@ -1,0 +1,28 @@
+import { Search } from "lucide-react";
+
+const SearchBar = () => {
+  return (
+    <div className="mb-6">
+      <div className="relative">
+        <Search
+        //size: width and height 
+          size={18}
+          //translate-y-1/2 : center it vertically, move it up by half of its height
+          className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
+        />
+        <input
+          type="text"
+          placeholder="Search books by title"
+          /*py: padding top and bottom,
+            outline: line that is drawn around elements, OUTSIDE the borders, to make the element "stand out",
+            focus: change the border color when focused
+          */
+
+          className="w-full rounded-xl border border-gray-300 bg-white py-2.5 pl-10 pr-4 text-sm outline-none focus:border-gray-400"
+        />
+      </div>
+    </div>
+  );
+};
+
+export default SearchBar;

--- a/PBL2/Pustakalaya/frontend/src/data/dummyBooks.js
+++ b/PBL2/Pustakalaya/frontend/src/data/dummyBooks.js
@@ -1,0 +1,30 @@
+// src/data/dummyBooks.js
+export const dummyBooks = [
+  {
+    id: 1,
+    title: "The Midnight Library",
+    author: "Matt Haig",
+    category: "Fiction",
+    coverImage:
+      "https://images.unsplash.com/photo-1544947950-fa07a98d237f?w=400",
+    isFavorite: false,
+  },
+  {
+    id: 2,
+    title: "Atomic Habits",
+    author: "James Clear",
+    category: "Self-Help",
+    coverImage:
+      "https://images.unsplash.com/photo-1512820790803-83ca734da794?w=400",
+    isFavorite: true,
+  },
+  {
+    id: 3,
+    title: "The Great Gatsby",
+    author: "F. Scott Fitzgerald",
+    category: "Classics",
+    coverImage:
+      "https://images.unsplash.com/photo-1544947950-fa07a98d237f?w=400",
+    isFavorite: true,
+  },
+];

--- a/PBL2/Pustakalaya/frontend/src/pages/Home.jsx
+++ b/PBL2/Pustakalaya/frontend/src/pages/Home.jsx
@@ -1,19 +1,16 @@
-import { useEffect } from "react";
-import API_URL from "../config/api";
+import BookGrid from "../components/BookGrid";
+import SearchBar from "../components/SearchBar";
+import { dummyBooks } from "../data/dummyBooks";
 
 const Home = () => {
-  useEffect(() => {
-    fetch("/api/books")
-      .then(() => console.log("Backend connected"))
-      .catch(() => {});
-  }, []);
-
   return (
-    <div>
-      <h1 className="font-serif font-bold text-2xl text-gray-900 mb-4 text-center">
-        Welcome to TEJ Pustakalaya
-      </h1>
-    </div>
+    <>
+      <main className="mx-auto max-w-7xl px-4 py-8">
+        <SearchBar />
+        <h1 className="font-serif mb-6 text-2xl font-bold">Top Picks</h1>
+        <BookGrid books={dummyBooks} />
+      </main>
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary

- This PR adds a simple books browsing section to the home page.
- Users can now see book cards in a grid layout and a search input area at the top.

## Changes Made

- Adds reusable UI components for book display and search.
- Connects the home page to show a list of books using local dummy data.


## Screenshots

<img width="1566" height="671" alt="Screenshot from 2026-03-19 19-40-56" src="https://github.com/user-attachments/assets/5500e49f-abee-49b5-a3c1-535a2b00bf72" />

- Linked issues: Closes #807 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added search bar to the home page for browsing books
  * Introduced responsive book grid displaying individual book cards
  * Each book card shows cover image, title, author, and category information
  * Added favorite/bookmark button to each book card

<!-- end of auto-generated comment: release notes by coderabbit.ai -->