### PR TITLE
feat(frontend): [1/n] implement functional favorites toggle with localStorage persistence

### DIFF
--- a/PBL2/Pustakalaya/.gitignore
+++ b/PBL2/Pustakalaya/.gitignore
@@ -1,2 +1,3 @@
 scripts/
 cursorrules/
+temp/

--- a/PBL2/Pustakalaya/frontend/src/components/BookCard.jsx
+++ b/PBL2/Pustakalaya/frontend/src/components/BookCard.jsx
@@ -30,6 +30,11 @@ const BookCard = ({ book, onBookClick, isFavorite, onToggleFavorite }) => {
             e.stopPropagation();
             onToggleFavorite(book.id);
           }}
+          onKeyDown={(e) => {  
+                       if (e.key === "Enter" || e.key === " ") {  
+                          e.stopPropagation();  
+                        }  
+                      }}  
           aria-label={isFavorite ? "Remove from favorites" : "Add to favorites"}
         >
           <Heart

--- a/PBL2/Pustakalaya/frontend/src/components/BookCard.jsx
+++ b/PBL2/Pustakalaya/frontend/src/components/BookCard.jsx
@@ -1,6 +1,6 @@
 import { Heart } from "lucide-react";
 
-const BookCard = ({ book, onBookClick }) => {
+const BookCard = ({ book, onBookClick, isFavorite, onToggleFavorite }) => {
   return (
     <div
       className="overflow-hidden rounded-2xl bg-white shadow-md hover:shadow-lg transition"
@@ -28,12 +28,14 @@ const BookCard = ({ book, onBookClick }) => {
           className="absolute right-3 top-3 rounded-full bg-white/90 p-2 shadow"
           onClick={(e) => {
             e.stopPropagation();
+            onToggleFavorite(book.id);
           }}
+          aria-label={isFavorite ? "Remove from favorites" : "Add to favorites"}
         >
           <Heart
             size={18}
             className={
-              book.isFavorite ? "fill-red-500 text-red-500" : "text-gray-600"
+              isFavorite ? "fill-red-500 text-red-500" : "text-gray-600"
             }
           />
         </button>

--- a/PBL2/Pustakalaya/frontend/src/components/BookCard.jsx
+++ b/PBL2/Pustakalaya/frontend/src/components/BookCard.jsx
@@ -30,11 +30,12 @@ const BookCard = ({ book, onBookClick, isFavorite, onToggleFavorite }) => {
             e.stopPropagation();
             onToggleFavorite(book.id);
           }}
-          onKeyDown={(e) => {  
-                       if (e.key === "Enter" || e.key === " ") {  
-                          e.stopPropagation();  
-                        }  
-                      }}  
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.stopPropagation();
+              e.preventDefault();
+            }
+          }}
           aria-label={isFavorite ? "Remove from favorites" : "Add to favorites"}
         >
           <Heart

--- a/PBL2/Pustakalaya/frontend/src/components/BookGrid.jsx
+++ b/PBL2/Pustakalaya/frontend/src/components/BookGrid.jsx
@@ -4,9 +4,13 @@ const BookGrid = ({ books, onBookClick, favoriteSet, onToggleFavorite }) => {
   return (
     <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
       {books.map((book) => (
-        <BookCard key={book.id} book={book} onBookClick={onBookClick} isFavorite={favoriteSet?.has(String(book.id))}
-        onToggleFavorite={onToggleFavorite}
-/>
+        <BookCard
+          key={book.id}
+          book={book}
+          onBookClick={onBookClick}
+          isFavorite={favoriteSet?.has(String(book.id))}
+          onToggleFavorite={onToggleFavorite}
+        />
       ))}
     </div>
   );

--- a/PBL2/Pustakalaya/frontend/src/components/BookGrid.jsx
+++ b/PBL2/Pustakalaya/frontend/src/components/BookGrid.jsx
@@ -1,10 +1,12 @@
 import BookCard from "./BookCard";
 
-const BookGrid = ({ books, onBookClick }) => {
+const BookGrid = ({ books, onBookClick, favoriteSet, onToggleFavorite }) => {
   return (
     <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
       {books.map((book) => (
-        <BookCard key={book.id} book={book} onBookClick={onBookClick} />
+        <BookCard key={book.id} book={book} onBookClick={onBookClick} isFavorite={favoriteSet?.has(String(book.id))}
+        onToggleFavorite={onToggleFavorite}
+/>
       ))}
     </div>
   );

--- a/PBL2/Pustakalaya/frontend/src/components/BookModal.jsx
+++ b/PBL2/Pustakalaya/frontend/src/components/BookModal.jsx
@@ -1,8 +1,6 @@
-import { X, BookOpen, Download, Star, Heart } from "lucide-react";
+import { X, BookOpen, Download, Star } from "lucide-react";
 
-// A modal component that displays selected book details and closes when clicking outside or on the close button.
 const BookModal = ({ book, onClose }) => {
-  // If no book is passed, don't render anything
   if (!book) return null;
   const rating = book.rating ?? 4.6;
   const reviews =
@@ -12,16 +10,13 @@ const BookModal = ({ book, onClose }) => {
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
-      {/* Backdrop */}
       <div
         className="absolute inset-0 bg-black/50"
         onClick={onClose}
         aria-hidden="true"
       />
 
-      {/* Modal card */}
       <div className="relative z-10 w-[92%] max-w-3xl rounded-2xl bg-white p-6 shadow-xl">
-        {/* Close button */}
         <button
           type="button"
           onClick={onClose}
@@ -32,14 +27,12 @@ const BookModal = ({ book, onClose }) => {
         </button>
 
         <div className="grid gap-6 md:grid-cols-[220px_1fr]">
-          {/* Cover */}
           <img
             src={book.coverImage}
             alt={book.title}
             className="h-72 w-full rounded-xl object-cover md:h-80"
           />
 
-          {/* Details */}
           <div>
             <h2 className="font-serif text-2xl font-bold text-gray-900">
               {book.title}
@@ -50,7 +43,6 @@ const BookModal = ({ book, onClose }) => {
               {book.category}
             </span>
 
-            {/* Rating + Favorites */}
             <div className="mt-4">
               <div className="flex items-center gap-1">
                 {[...Array(5)].map((_, i) => (
@@ -79,6 +71,8 @@ const BookModal = ({ book, onClose }) => {
             </p>
 {/* TODO: Will add onClick handlers for read full book and borrow book buttons */}
             <div className="mt-6 flex flex-col gap-3 sm:flex-row">
+            
+
               <button
                 type="button"
                 className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-50"

--- a/PBL2/Pustakalaya/frontend/src/components/BooksSection.jsx
+++ b/PBL2/Pustakalaya/frontend/src/components/BooksSection.jsx
@@ -6,6 +6,8 @@ const BooksSection = ({
   error,
   onRetry,
   onBookClick,
+  favoriteSet,
+  onToggleFavorite,
   emptyMessage = "No books found.",
 }) => {
   if (isLoading) {
@@ -38,7 +40,8 @@ const BooksSection = ({
     return <div>{emptyMessage}</div>;
   }
 
-  return <BookGrid books={books} onBookClick={onBookClick} />;
+  return <BookGrid books={books} onBookClick={onBookClick} favoriteSet={favoriteSet}
+  onToggleFavorite={onToggleFavorite} />;
 };
 
 export default BooksSection;

--- a/PBL2/Pustakalaya/frontend/src/context/FavoritesContext.jsx
+++ b/PBL2/Pustakalaya/frontend/src/context/FavoritesContext.jsx
@@ -1,0 +1,21 @@
+import { createContext, useContext } from "react";
+import useFavorites from "../hooks/useFavorites";
+
+const FavoritesContext = createContext(null);
+
+export function FavoritesProvider({ children }) {
+  const value = useFavorites();
+  return (
+    <FavoritesContext.Provider value={value}>
+      {children}
+    </FavoritesContext.Provider>
+  );
+}
+
+export function useFavoritesContext() {
+  const ctx = useContext(FavoritesContext);
+  if (!ctx) {
+    throw new Error("useFavoritesContext must be used within FavoritesProvider");
+  }
+  return ctx;
+}

--- a/PBL2/Pustakalaya/frontend/src/hooks/useFavorites.js
+++ b/PBL2/Pustakalaya/frontend/src/hooks/useFavorites.js
@@ -2,8 +2,19 @@ import { useMemo, useState } from "react";
 
 const FAVORITES_KEY = "guest_favorites";
 
+/**
+* Safely retrieves and cleans the user's favorite IDs from local storage.
+* - Parses text into an Array; returns [] if empty or broken.
+* - Ensures all IDs are Strings; wipes storage if data is corrupted.
+*/
 function getInitialFavoriteIds() {
-  const raw = localStorage.getItem(FAVORITES_KEY);
+  let raw = null;
+  try {
+    raw = localStorage.getItem(FAVORITES_KEY);
+  } catch (error) {
+    console.error("Error reading favorites from localStorage:", error);
+    raw = null;
+  }
   if (!raw) return [];
 
   try {
@@ -11,7 +22,11 @@ function getInitialFavoriteIds() {
     //parsed.map(String): ensures every item in the list is a String. If the list was [1, 2], it becomes ["1", "2"]
     return Array.isArray(parsed) ? parsed.map(String) : [];
   } catch {
-    localStorage.removeItem(FAVORITES_KEY);
+    try {
+      localStorage.removeItem(FAVORITES_KEY);
+    } catch (error) {
+      console.error("Error removing favorites from localStorage:", error);
+    }
     return [];
   }
 }
@@ -19,45 +34,56 @@ function getInitialFavoriteIds() {
 export default function useFavorites() {
   const [favoriteIds, setFavoriteIds] = useState(getInitialFavoriteIds);
 
-  //set - fast lookup, no duplicates , 
+  //set - fast lookup, no duplicates 
   //useMemo - remember the result of the function call and only recompute it if the dependencies change
   const favoriteSet = useMemo(() => new Set(favoriteIds), [favoriteIds]);
 
   //updates the screen and the localStorage
-  const persist = (nextIds) => {
-    setFavoriteIds(nextIds);
-    localStorage.setItem(FAVORITES_KEY, JSON.stringify(nextIds));
+  const persist = (updater) => {
+    setFavoriteIds((prev) => {
+      const nextIds = typeof updater === "function" ? updater(prev) : updater;
+
+      try {
+        localStorage.setItem(FAVORITES_KEY, JSON.stringify(nextIds));
+      } catch (error) {
+        console.error("Failed to save favorites to localStorage:", error);
+      }
+
+      return nextIds;
+    });
   };
 
   //checks if the book is in the favorites list
   const isFavorite = (bookId) => favoriteSet.has(String(bookId));
 
-  // Checks if a book is already favorited and adds it if it's missing
+  // adds a book to the favorites list, also makes sure there are no duplicates
   const addFavorite = (bookId) => {
-    if (isFavorite(bookId)) return;
-    persist([...favoriteIds, String(bookId)]);
+    const id = String(bookId);
+    persist((prev) => (prev.includes(id) ? prev : [...prev, id]));
   };
 
-// Removes one specific book from the favorites list
+  // Removes one specific book from the favorites list
   const removeFavorite = (bookId) => {
     const id = String(bookId);
-    if (!isFavorite(bookId)) return;
-    persist(favoriteIds.filter((x) => x !== id));
+    persist((prev) => prev.filter((x) => x !== id));
   };
 
   // Switches a book between favorited and unfavorited states
   const toggleFavorite = (bookId) => {
-    if (isFavorite(bookId)) {
-      removeFavorite(bookId);
-    } else {
-      addFavorite(bookId);
-    }
+    const id = String(bookId);
+    persist((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id],
+    );
   };
 
   // Completely wipes all saved favorites and clears storage
   const clearFavorites = () => {
     setFavoriteIds([]);
-    localStorage.removeItem(FAVORITES_KEY);
+    try {
+      localStorage.removeItem(FAVORITES_KEY);
+    } catch (error) {
+      console.error("Error clearing favorites from localStorage:", error);
+    }
   };
 
   return {

--- a/PBL2/Pustakalaya/frontend/src/hooks/useFavorites.js
+++ b/PBL2/Pustakalaya/frontend/src/hooks/useFavorites.js
@@ -1,0 +1,72 @@
+import { useMemo, useState } from "react";
+
+const FAVORITES_KEY = "guest_favorites";
+
+function getInitialFavoriteIds() {
+  const raw = localStorage.getItem(FAVORITES_KEY);
+  if (!raw) return [];
+
+  try {
+    const parsed = JSON.parse(raw);
+    //parsed.map(String): ensures every item in the list is a String. If the list was [1, 2], it becomes ["1", "2"]
+    return Array.isArray(parsed) ? parsed.map(String) : [];
+  } catch {
+    localStorage.removeItem(FAVORITES_KEY);
+    return [];
+  }
+}
+
+export default function useFavorites() {
+  const [favoriteIds, setFavoriteIds] = useState(getInitialFavoriteIds);
+
+  //set - fast lookup, no duplicates , 
+  //useMemo - remember the result of the function call and only recompute it if the dependencies change
+  const favoriteSet = useMemo(() => new Set(favoriteIds), [favoriteIds]);
+
+  //updates the screen and the localStorage
+  const persist = (nextIds) => {
+    setFavoriteIds(nextIds);
+    localStorage.setItem(FAVORITES_KEY, JSON.stringify(nextIds));
+  };
+
+  //checks if the book is in the favorites list
+  const isFavorite = (bookId) => favoriteSet.has(String(bookId));
+
+  // Checks if a book is already favorited and adds it if it's missing
+  const addFavorite = (bookId) => {
+    if (isFavorite(bookId)) return;
+    persist([...favoriteIds, String(bookId)]);
+  };
+
+// Removes one specific book from the favorites list
+  const removeFavorite = (bookId) => {
+    const id = String(bookId);
+    if (!isFavorite(bookId)) return;
+    persist(favoriteIds.filter((x) => x !== id));
+  };
+
+  // Switches a book between favorited and unfavorited states
+  const toggleFavorite = (bookId) => {
+    if (isFavorite(bookId)) {
+      removeFavorite(bookId);
+    } else {
+      addFavorite(bookId);
+    }
+  };
+
+  // Completely wipes all saved favorites and clears storage
+  const clearFavorites = () => {
+    setFavoriteIds([]);
+    localStorage.removeItem(FAVORITES_KEY);
+  };
+
+  return {
+    favoriteIds,
+    favoriteSet,
+    isFavorite,
+    addFavorite,
+    removeFavorite,
+    toggleFavorite,
+    clearFavorites,
+  };
+}

--- a/PBL2/Pustakalaya/frontend/src/main.jsx
+++ b/PBL2/Pustakalaya/frontend/src/main.jsx
@@ -3,11 +3,14 @@ import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import "./index.css";
 import App from "./App.jsx";
+import { FavoritesProvider } from "./context/FavoritesContext.jsx";
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>
     <BrowserRouter>
-      <App />
+      <FavoritesProvider>
+        <App />
+      </FavoritesProvider>
     </BrowserRouter>
   </StrictMode>,
 );

--- a/PBL2/Pustakalaya/frontend/src/pages/Favorites.jsx
+++ b/PBL2/Pustakalaya/frontend/src/pages/Favorites.jsx
@@ -1,12 +1,12 @@
 import { useMemo, useState } from "react";
 import useBooks from "../hooks/useBooks";
-import useFavorites from "../hooks/useFavorites";
+import { useFavoritesContext } from "../context/FavoritesContext";
 import BooksSection from "../components/BooksSection";
 import BookModal from "../components/BookModal";
 
 const Favorites = () => {
   const { books, isLoading, error, reload } = useBooks();
-  const { favoriteSet, isFavorite, toggleFavorite } = useFavorites();
+  const { favoriteSet, toggleFavorite } = useFavoritesContext();
   const [selectedBook, setSelectedBook] = useState(null);
 
   const favoriteBooks = useMemo(
@@ -30,12 +30,7 @@ const Favorites = () => {
       />
 
       {selectedBook && (
-        <BookModal
-          book={selectedBook}
-          onClose={() => setSelectedBook(null)}
-          isFavorite={isFavorite(selectedBook.id)}
-          onToggleFavorite={toggleFavorite}
-        />
+        <BookModal book={selectedBook} onClose={() => setSelectedBook(null)} />
       )}
     </div>
   );

--- a/PBL2/Pustakalaya/frontend/src/pages/Favorites.jsx
+++ b/PBL2/Pustakalaya/frontend/src/pages/Favorites.jsx
@@ -1,7 +1,42 @@
+import { useMemo, useState } from "react";
+import useBooks from "../hooks/useBooks";
+import useFavorites from "../hooks/useFavorites";
+import BooksSection from "../components/BooksSection";
+import BookModal from "../components/BookModal";
+
 const Favorites = () => {
+  const { books, isLoading, error, reload } = useBooks();
+  const { favoriteSet, isFavorite, toggleFavorite } = useFavorites();
+  const [selectedBook, setSelectedBook] = useState(null);
+
+  const favoriteBooks = useMemo(
+    () => books.filter((book) => favoriteSet.has(String(book.id))),
+    [books, favoriteSet],
+  );
+
   return (
     <div className="py-8">
-      <h1>My Favorites</h1>
+      <h1 className="font-serif mb-6 text-2xl font-bold">My Favorites</h1>
+
+      <BooksSection
+        books={favoriteBooks}
+        isLoading={isLoading}
+        error={error}
+        onRetry={reload}
+        onBookClick={setSelectedBook}
+        favoriteSet={favoriteSet}
+        onToggleFavorite={toggleFavorite}
+        emptyMessage="You have no favorite books yet."
+      />
+
+      {selectedBook && (
+        <BookModal
+          book={selectedBook}
+          onClose={() => setSelectedBook(null)}
+          isFavorite={isFavorite(selectedBook.id)}
+          onToggleFavorite={toggleFavorite}
+        />
+      )}
     </div>
   );
 };

--- a/PBL2/Pustakalaya/frontend/src/pages/Home.jsx
+++ b/PBL2/Pustakalaya/frontend/src/pages/Home.jsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import useBooks from "../hooks/useBooks";
-import useFavorites from "../hooks/useFavorites";
+import { useFavoritesContext } from "../context/FavoritesContext";
 import SearchBar from "../components/SearchBar";
 import BookModal from "../components/BookModal";
 import BooksSection from "../components/BooksSection";
@@ -8,7 +8,7 @@ import BooksSection from "../components/BooksSection";
 const Home = () => {
   const { books, searchTerm, setSearchTerm, isLoading, error, reload } =
     useBooks();
-    const { favoriteSet, isFavorite, toggleFavorite} = useFavorites();
+    const { favoriteSet, toggleFavorite} = useFavoritesContext();
   const [selectedBook, setSelectedBook] = useState(null);
 
   const openBookModal = (book) => {
@@ -40,8 +40,7 @@ const Home = () => {
 
       {/* modal opens only when selectedBook exists */}
       {selectedBook && (
-        <BookModal book={selectedBook} onClose={closeBookModal} isFavorite={isFavorite(selectedBook.id)}
-        onToggleFavorite={toggleFavorite} />
+        <BookModal book={selectedBook} onClose={closeBookModal} />
       )}
     </main>
   );

--- a/PBL2/Pustakalaya/frontend/src/pages/Home.jsx
+++ b/PBL2/Pustakalaya/frontend/src/pages/Home.jsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import useBooks from "../hooks/useBooks";
+import useFavorites from "../hooks/useFavorites";
 import SearchBar from "../components/SearchBar";
 import BookModal from "../components/BookModal";
 import BooksSection from "../components/BooksSection";
@@ -7,6 +8,7 @@ import BooksSection from "../components/BooksSection";
 const Home = () => {
   const { books, searchTerm, setSearchTerm, isLoading, error, reload } =
     useBooks();
+    const { favoriteSet, isFavorite, toggleFavorite} = useFavorites();
   const [selectedBook, setSelectedBook] = useState(null);
 
   const openBookModal = (book) => {
@@ -27,6 +29,8 @@ const Home = () => {
         error={error}
         onRetry={reload}
         onBookClick={openBookModal}
+        favoriteSet={favoriteSet}
+        onToggleFavorite={toggleFavorite}
         emptyMessage={
           searchTerm
             ? `No books found for "${searchTerm}".`
@@ -36,7 +40,8 @@ const Home = () => {
 
       {/* modal opens only when selectedBook exists */}
       {selectedBook && (
-        <BookModal book={selectedBook} onClose={closeBookModal} />
+        <BookModal book={selectedBook} onClose={closeBookModal} isFavorite={isFavorite(selectedBook.id)}
+        onToggleFavorite={toggleFavorite} />
       )}
     </main>
   );


### PR DESCRIPTION
## Summary

- Built a working favorites feature with add/remove/toggle behavior, heart button UI updates, shared state across screens, and local storage persistence so favorites stay saved after refresh.

## Screenshots
[Screencast from 24-3-26 09:16:26 अपराह्न +0545.webm](https://github.com/user-attachments/assets/89cc21de-6844-45f5-99c9-cf434239ab77)

- Linked issues: Closes #830 

## Additional Notes

- Favorites are stored client-side in localStorage; no API update is performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to mark and toggle books as favorites throughout the app
  * Created dedicated Favorites page to view and manage saved favorites
  * Favorites persist across browser sessions

* **Refactor**
  * Cleaned up component imports and removed unnecessary comments

* **Chores**
  * Updated `.gitignore` to exclude temporary files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->