### PR TITLE
feat: redirect unauthenticated users to /auth (dummy auth + borrow intent)

### DIFF
--- a/PBL2/Pustakalaya/frontend/src/App.jsx
+++ b/PBL2/Pustakalaya/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import MainLayout from "./layout/MainLayout";
 import Home from "./pages/Home";
 import Auth from "./pages/Auth";
 import Favorites from "./pages/Favorites";
+import MyShelf from "./pages/MyShelf";
 
 const App = () => {
   return (
@@ -12,6 +13,7 @@ const App = () => {
         <Route path="/favorites" element={<Favorites />} />
       </Route>
       <Route path="/auth" element={<Auth />} />
+      <Route path="/my-shelf" element={<MyShelf />} />
     </Routes>
   );
 };

--- a/PBL2/Pustakalaya/frontend/src/App.jsx
+++ b/PBL2/Pustakalaya/frontend/src/App.jsx
@@ -4,6 +4,7 @@ import Home from "./pages/Home";
 import Auth from "./pages/Auth";
 import Favorites from "./pages/Favorites";
 import MyShelf from "./pages/MyShelf";
+import RequireAuth from "./components/RequireAuth";
 
 const App = () => {
   return (
@@ -13,7 +14,7 @@ const App = () => {
         <Route path="/favorites" element={<Favorites />} />
       </Route>
       <Route path="/auth" element={<Auth />} />
-      <Route path="/my-shelf" element={<MyShelf />} />
+      <Route path="/my-shelf" element={<RequireAuth><MyShelf /></RequireAuth>} />
     </Routes>
   );
 };

--- a/PBL2/Pustakalaya/frontend/src/components/BookModal.jsx
+++ b/PBL2/Pustakalaya/frontend/src/components/BookModal.jsx
@@ -1,7 +1,8 @@
 import { X, BookOpen, Download, Star, Heart } from "lucide-react";
 
+
 // A modal component that displays selected book details and closes when clicking outside or on the close button.
-const BookModal = ({ book, onClose }) => {
+const BookModal = ({ book, onClose, onBorrow }) => {
   // If no book is passed, don't render anything
   if (!book) return null;
   const rating = book.rating ?? 4.6;
@@ -9,6 +10,8 @@ const BookModal = ({ book, onClose }) => {
     typeof book.reviews === "number"
       ? book.reviews.toLocaleString()
       : (book.reviews ?? "2,891");
+
+         
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
@@ -89,6 +92,7 @@ const BookModal = ({ book, onClose }) => {
 
               <button
                 type="button"
+                onClick={() => onBorrow?.(book)}
                 className="inline-flex items-center justify-center gap-2 rounded-lg bg-blue-700 px-4 py-2 text-sm font-medium text-white transition hover:bg-blue-800"
               >
                 <Download size={16} />

--- a/PBL2/Pustakalaya/frontend/src/components/RequireAuth.jsx
+++ b/PBL2/Pustakalaya/frontend/src/components/RequireAuth.jsx
@@ -1,0 +1,21 @@
+import { Navigate, useLocation } from "react-router-dom";
+import { useAuth } from "../context/AuthContext.jsx";
+
+/**
+ * A Route Guard that redirects unauthenticated users to the /auth page.
+ * It saves the current location so the user can be sent back after login.
+ */
+export default function RequireAuth({ children }) {
+  const { isAuthenticated } = useAuth();
+  const location = useLocation();  //looks at the browser's address bar and grabs the current URL (like /my-shelf)
+
+  if (!isAuthenticated) {
+    return (
+        // Replace the current entry in history to prevent "back button" loops
+        // Pass the current path as 'state' so we can redirect back here after login
+      <Navigate to="/auth" replace state={{ from: location.pathname }} />
+    );
+  }
+
+  return children;
+}

--- a/PBL2/Pustakalaya/frontend/src/context/AuthContext.jsx
+++ b/PBL2/Pustakalaya/frontend/src/context/AuthContext.jsx
@@ -1,0 +1,38 @@
+// TODO: This is a dummy auth context, will replace with the actual auth context later.
+import {
+    createContext,
+    useCallback,
+    useContext,
+    useMemo,
+    useState,
+  } from "react";
+  
+  const AuthContext = createContext(null);
+  
+  export function AuthProvider({ children }) {
+    // Dummy auth state: start false so guards/redirects work immediately later.
+    const [isAuthenticated, setIsAuthenticated] = useState(false);
+  
+    const login = useCallback(() => {
+      setIsAuthenticated(true);
+    }, []);
+  
+    const logout = useCallback(() => {
+      setIsAuthenticated(false);
+    }, []);
+  
+    const value = useMemo(
+      () => ({ isAuthenticated, login, logout }),
+      [isAuthenticated, login, logout]
+    );
+  
+    return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+  }
+  
+  export function useAuth() {
+    const ctx = useContext(AuthContext);
+    if (!ctx) {
+      throw new Error("useAuth must be used inside <AuthProvider>.");
+    }
+    return ctx;
+  }

--- a/PBL2/Pustakalaya/frontend/src/main.jsx
+++ b/PBL2/Pustakalaya/frontend/src/main.jsx
@@ -3,11 +3,14 @@ import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import "./index.css";
 import App from "./App.jsx";
+import { AuthProvider } from "./context/AuthContext.jsx";
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>
     <BrowserRouter>
-      <App />
+      <AuthProvider>
+        <App />
+      </AuthProvider>
     </BrowserRouter>
   </StrictMode>,
 );

--- a/PBL2/Pustakalaya/frontend/src/pages/Auth.jsx
+++ b/PBL2/Pustakalaya/frontend/src/pages/Auth.jsx
@@ -1,9 +1,39 @@
+import { useNavigate, useLocation } from "react-router-dom";
+import { useAuth } from "../context/AuthContext";
+import { consumePendingBorrow } from "../utils/pendingBorrowStorage";
+
 const Auth = () => {
-    return (
-        <div>
-            <h1>Auth Page</h1>
-        </div>
-    )
-}
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { login } = useAuth();
+
+  function handleLoginSuccess() {
+    login();
+    const pendingBookId = consumePendingBorrow();
+    if (pendingBookId) {
+      navigate(`/my-shelf?bookId=${encodeURIComponent(pendingBookId)}`, {
+        replace: true,
+      });
+      return;
+    }
+    const from = location.state?.from;
+    const safeFrom =
+      typeof from === "string" && from.startsWith("/") && from !== "/auth"
+        ? from
+        : "/";
+    navigate(safeFrom, { replace: true });
+  }
+
+  return (
+    <div>
+      <h1>Auth Page</h1>
+      {/* TODO: Wire this to the real auth flow; call handleLoginSuccess when login succeeds */}
+      <button type="button" onClick={handleLoginSuccess}   className="mt-4 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-800 hover:bg-gray-50"
+      >
+        Continue (dummy login)
+      </button>
+    </div>
+  );
+};
 
 export default Auth;

--- a/PBL2/Pustakalaya/frontend/src/pages/Auth.jsx
+++ b/PBL2/Pustakalaya/frontend/src/pages/Auth.jsx
@@ -10,17 +10,24 @@ const Auth = () => {
   function handleLoginSuccess() {
     login();
     const pendingBookId = consumePendingBorrow();
-    if (pendingBookId) {
+    if (
+      pendingBookId !== null &&
+      pendingBookId !== undefined &&
+      pendingBookId !== ""
+    ) {
       navigate(`/my-shelf?bookId=${encodeURIComponent(pendingBookId)}`, {
         replace: true,
       });
       return;
     }
     const from = location.state?.from;
-    const safeFrom =
-      typeof from === "string" && from.startsWith("/") && from !== "/auth"
-        ? from
-        : "/";
+    const isSafePath =
+      typeof from === "string" &&
+      from.startsWith("/") &&
+      !from.startsWith("//") &&
+      !from.startsWith("/\\");
+
+    const safeFrom = isSafePath && from !== "/auth" ? from : "/";
     navigate(safeFrom, { replace: true });
   }
 
@@ -28,7 +35,10 @@ const Auth = () => {
     <div>
       <h1>Auth Page</h1>
       {/* TODO: Wire this to the real auth flow; call handleLoginSuccess when login succeeds */}
-      <button type="button" onClick={handleLoginSuccess}   className="mt-4 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-800 hover:bg-gray-50"
+      <button
+        type="button"
+        onClick={handleLoginSuccess}
+        className="mt-4 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm text-gray-800 hover:bg-gray-50"
       >
         Continue (dummy login)
       </button>

--- a/PBL2/Pustakalaya/frontend/src/pages/Home.jsx
+++ b/PBL2/Pustakalaya/frontend/src/pages/Home.jsx
@@ -1,5 +1,8 @@
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import useBooks from "../hooks/useBooks";
+import { useAuth } from "../context/AuthContext";
+import { setPendingBorrow } from "../utils/pendingBorrowStorage";
 import SearchBar from "../components/SearchBar";
 import BookModal from "../components/BookModal";
 import BooksSection from "../components/BooksSection";
@@ -8,6 +11,9 @@ const Home = () => {
   const { books, searchTerm, setSearchTerm, isLoading, error, reload } =
     useBooks();
   const [selectedBook, setSelectedBook] = useState(null);
+const navigate = useNavigate();
+const { isAuthenticated } = useAuth();
+
 
   const openBookModal = (book) => {
     setSelectedBook(book);
@@ -15,6 +21,17 @@ const Home = () => {
 
   const closeBookModal = () => {
     setSelectedBook(null);
+  };
+
+  const handleBorrow = (book) => {
+    if (!book?.id) return;
+    if (!isAuthenticated) {
+      setPendingBorrow(book.id);
+      navigate("/auth");
+      closeBookModal();
+      return;
+    }
+    // Logged in: stub for real borrow API later
   };
 
   return (
@@ -36,7 +53,7 @@ const Home = () => {
 
       {/* modal opens only when selectedBook exists */}
       {selectedBook && (
-        <BookModal book={selectedBook} onClose={closeBookModal} />
+        <BookModal book={selectedBook} onClose={closeBookModal} onBorrow={handleBorrow} />
       )}
     </main>
   );

--- a/PBL2/Pustakalaya/frontend/src/pages/Home.jsx
+++ b/PBL2/Pustakalaya/frontend/src/pages/Home.jsx
@@ -11,9 +11,8 @@ const Home = () => {
   const { books, searchTerm, setSearchTerm, isLoading, error, reload } =
     useBooks();
   const [selectedBook, setSelectedBook] = useState(null);
-const navigate = useNavigate();
-const { isAuthenticated } = useAuth();
-
+  const navigate = useNavigate();
+  const { isAuthenticated } = useAuth();
 
   const openBookModal = (book) => {
     setSelectedBook(book);
@@ -53,7 +52,11 @@ const { isAuthenticated } = useAuth();
 
       {/* modal opens only when selectedBook exists */}
       {selectedBook && (
-        <BookModal book={selectedBook} onClose={closeBookModal} onBorrow={handleBorrow} />
+        <BookModal
+          book={selectedBook}
+          onClose={closeBookModal}
+          onBorrow={handleBorrow}
+        />
       )}
     </main>
   );

--- a/PBL2/Pustakalaya/frontend/src/pages/MyShelf.jsx
+++ b/PBL2/Pustakalaya/frontend/src/pages/MyShelf.jsx
@@ -1,0 +1,9 @@
+const MyShelf = () => {
+  return (
+    <div className="py-8">
+      <h1>My Shelf</h1>
+    </div>
+  );
+};
+
+export default MyShelf;

--- a/PBL2/Pustakalaya/frontend/src/utils/pendingBorrowStorage.js
+++ b/PBL2/Pustakalaya/frontend/src/utils/pendingBorrowStorage.js
@@ -1,0 +1,37 @@
+const STORAGE_KEY = "pustakalaya_pendingBorrowBookId";
+
+/*
+typeof window !== "undefined": Checks if we are actually in a browser (and not on a server).
+
+window.localStorage != null: Checks if the browser allows us to save things.*/ 
+function canUseStorage() {
+    return typeof window !== "undefined" && window.localStorage != null;
+  }
+
+  // set the pending borrow book id to the local storage
+  export function setPendingBorrow(bookId) {
+    if (!canUseStorage()) return;
+    const id = bookId?.toString().trim() ?? "";    // if bookId is null or undefined, set it to an empty string
+    if (!id) return;  // if id is an empty string, return
+    try {
+      window.localStorage.setItem(STORAGE_KEY, id);
+    } catch {
+      // Quota / private mode — ignore
+    }
+  }
+
+/**
+ * Reads the saved book ID from storage and immediately deletes it.
+ * To be used after login to finish a 'pending' borrow action exactly once.
+ */
+  export function consumePendingBorrow() {
+    if (!canUseStorage()) return null;
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      window.localStorage.removeItem(STORAGE_KEY);
+      const id = raw?.trim();
+      return id || null;
+    } catch {
+      return null;
+    }
+  }


### PR DESCRIPTION
## Summary

Visitors who are not logged in are sent to /auth when they try to use flows that require an account. This uses a temporary auth layer that the real login flow can replace later.

## Changes Made

- **RequireAuth**: Unauthenticated visits to /my-shelf redirect to /auth and pass the attempted path in navigation state.
- **AuthContext**: Dummy isAuthenticated plus login / logout for guards and redirects until real auth exists.
- **pendingBorrowStorage**: Saves the book id for a borrow click so it can be resumed after login.
- **Home + BookModal**: Borrow while logged out stores that id and navigates to /auth.
- **Auth**: Dummy “Continue” login runs post-login navigation (pending borrow → /my-shelf?bookId=…, else return to from or /).
- **main.jsx**: Wraps the app with AuthProvider inside BrowserRouter.
- **App.jsx**: Wraps /my-shelf with RequireAuth.


## Screenshots
[Screencast from 25-3-26 09:16:14 अपराह्न +0545.webm](https://github.com/user-attachments/assets/109c6f87-34b4-4030-b0ed-dd04550b2389)

- Linked issues: Closes #836

## Follow ups

- Replace dummy AuthContext with real session/token handling.
- Wire handleLoginSuccess (or equivalent) to the real auth success path instead of the placeholder button.
- Implement real borrow API when logged in (currently stubbed on Home).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented user authentication system with login and logout capabilities
  * Added "My Shelf" page for storing and managing borrowed books (authenticated users only)
  * Enhanced book borrowing workflow: unauthenticated users are prompted to log in before borrowing
  * Smart post-login navigation returns users to their intended destination

<!-- end of auto-generated comment: release notes by coderabbit.ai -->