### PR TITLE
feat(shelf): add 'My Shelf' to profile menu & implement  removal

### DIFF
--- a/PBL2/Pustakalaya/frontend/src/components/Navbar.jsx
+++ b/PBL2/Pustakalaya/frontend/src/components/Navbar.jsx
@@ -87,6 +87,19 @@ const Navbar = () => {
 
                 {isProfileOpen && (
                   <div className="absolute right-0 mt-2 w-40 rounded-lg border border-black/10 bg-white p-1 shadow-lg z-50">
+                     <NavLink
+                      to="/my-shelf"
+                      onClick={() => setIsProfileOpen(false)}
+                      className={({ isActive }) =>
+                        `flex w-full rounded-md px-3 py-2 text-left text-sm transition-colors ${
+                          isActive
+                            ? "bg-black/5 font-medium text-gray-900"
+                            : "text-gray-700 hover:bg-black/5"
+                        }`
+                      }
+                    >
+                      My Shelf
+                    </NavLink>
                     <button
                       type="button"
                       onClick={async () => {

--- a/PBL2/Pustakalaya/frontend/src/pages/MyShelf.jsx
+++ b/PBL2/Pustakalaya/frontend/src/pages/MyShelf.jsx
@@ -1,10 +1,13 @@
 import { useState } from "react";
-import { getShelfItems } from "../utils/shelfStorage";
+import { getShelfItems, removeShelfItem } from "../utils/shelfStorage";
 
 const MyShelf = () => {
-  const [items] = useState(() => getShelfItems());
+  const [items, setItems] = useState(() => getShelfItems());
 
-  
+  const handleRemove = (id) => {
+    const updatedItems = removeShelfItem(id);
+    setItems(updatedItems);
+  };
 
   return (
     <main className="mx-auto max-w-7xl px-4 py-8">
@@ -14,7 +17,9 @@ const MyShelf = () => {
       </p>
 
       {items.length === 0 ? (
-        <p className="mt-8 text-gray-600">Your shelf is empty. Borrow a book from Home.</p>
+        <p className="mt-8 text-gray-600">
+          Your shelf is empty. Borrow a book from Home.
+        </p>
       ) : (
         <ul className="mt-8 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
           {items.map((book) => (
@@ -32,6 +37,14 @@ const MyShelf = () => {
                   {book.title}
                 </h2>
                 <p className="mt-1 text-sm text-gray-600">by {book.author}</p>
+
+                {/* REMOVE BUTTON */}
+                <button
+                  onClick={() => handleRemove(book.id)}
+                  className="mt-4 w-full rounded-lg bg-red-50 py-2 text-sm font-medium text-red-600 hover:bg-red-100 transition-colors"
+                >
+                  Return Book
+                </button>
               </div>
             </li>
           ))}

--- a/PBL2/Pustakalaya/frontend/src/utils/shelfStorage.js
+++ b/PBL2/Pustakalaya/frontend/src/utils/shelfStorage.js
@@ -37,3 +37,18 @@ export function addShelfItem(item) {
   }
   return next;
 }
+
+export function removeShelfItem(id) {
+  if (!canUseStorage()) return [];
+  
+  const existing = getShelfItems();
+  // Keep everything EXCEPT the book we want to remove
+  const next = existing.filter((book) => book.id !== id);
+  
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+  } catch {
+    // ignore
+  }
+  return next;
+}


### PR DESCRIPTION


## Summary

This change makes it easier to open My Shelf after sign-in and to return books from the shelf. Borrowed titles live in local storage on the device, returning a book removes it from the shelf and updates the UI immediately.

## Screenshots

[Screencast from 29-3-26 09:02:54 अपराह्न +0545.webm](https://github.com/user-attachments/assets/4613a172-c3f8-4fa4-88a3-17adcaab5503)


-  Linked issues: Closes #845 #846 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "My Shelf" option to the user profile dropdown menu for easy access to your saved books.
  * Users can now manage their shelf by removing books using a "Return Book" button on each item, with instant updates reflected in the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->