### PR TITLE
feat: integrate frontend books hook with backend /api/books (replace db.json source)

### DIFF
--- a/PBL2/Pustakalaya/frontend/src/hooks/useBooks.js
+++ b/PBL2/Pustakalaya/frontend/src/hooks/useBooks.js
@@ -1,4 +1,6 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const SEARCH_DEBOUNCE_MS = 350;
 
 export default function useBooks() {
   const [books, setBooks] = useState([]);
@@ -6,33 +8,49 @@ export default function useBooks() {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(null);
 
+  // Prevent race conditions when multiple requests resolve out of order
+  const requestIdRef = useRef(0);
+
   const loadBooks = useCallback(async (query = "") => {
+    const requestId = ++requestIdRef.current;
+
     try {
       setIsLoading(true);
       setError(null);
 
-      const response = await fetch(`http://localhost:3001/books`);
+      const q = query.trim();
+      const params = new URLSearchParams();
+      if (q) params.set("q", q);
+
+      const response = await fetch(`/api/books?${params.toString()}`);
       if (!response.ok) {
         throw new Error("Failed to load books. Please try again.");
       }
+
       const data = await response.json();
 
-      const q = query.trim().toLowerCase();
-      const filtered = q
-        ? data.filter((book) => book.title.toLowerCase().includes(q))
-        : data;
-
-      setBooks(filtered);
+      // Only apply the latest request result
+      if (requestId === requestIdRef.current) {
+        setBooks(Array.isArray(data?.books) ? data.books : []);
+      }
     } catch (error) {
-      setError(error.message || "Failed to load books. Please try again.");
-      setBooks([]);
+      if (requestId === requestIdRef.current) {
+        setError(error.message || "Failed to load books. Please try again.");
+        setBooks([]);
+      }
     } finally {
-      setIsLoading(false);
+      if (requestId === requestIdRef.current) {
+        setIsLoading(false);
+      }
     }
   }, []);
 
   useEffect(() => {
-    loadBooks(searchTerm);
+    const timer = setTimeout(() => {
+      loadBooks(searchTerm);
+    }, SEARCH_DEBOUNCE_MS);
+
+    return () => clearTimeout(timer);
   }, [searchTerm, loadBooks]);
 
   const reload = useCallback(() => {


### PR DESCRIPTION

## Summary

- Replaced the frontend books data source from local `db.json`/json-server endpoint to backend API endpoint (`/api/books`).
- Updated `useBooks` to pass search input as query param (`q`) so filtering is handled by backend instead of client-side filtering.
- Added debounce to reduce request frequency while typing and guarded against stale responses overwriting newer results.

- Linked issues: Closes #801



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added search debouncing for a smoother, more responsive search experience.

* **Bug Fixes**
  * Fixed issue where search results could appear stale or out-of-order during rapid searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->