### PR TITLE
feat(StripeBot): add js-tiktoken helpers and token-based chunking

### DIFF
--- a/PBL4/StripeBot/.gitignore
+++ b/PBL4/StripeBot/.gitignore
@@ -1,0 +1,1 @@
+scripts/

--- a/PBL4/StripeBot/backend/.gitignore
+++ b/PBL4/StripeBot/backend/.gitignore
@@ -1,2 +1,2 @@
 node_modules/
-
+.env

--- a/PBL4/StripeBot/backend/package.json
+++ b/PBL4/StripeBot/backend/package.json
@@ -11,6 +11,8 @@
   "license": "ISC",
   "dependencies": {
     "20": "^3.1.9",
+    "@langchain/core": "^1.1.38",
+    "js-tiktoken": "^1.0.21",
     "nvm": "^0.0.4",
     "use": "^3.1.1"
   }

--- a/PBL4/StripeBot/backend/src/utils/chunker.js
+++ b/PBL4/StripeBot/backend/src/utils/chunker.js
@@ -1,0 +1,82 @@
+const {
+  countTokens,
+  truncateToTokenLimit,
+  getTokenizer,
+} = require("../utils/tokenCounter");
+
+/**
+ * Grabs a specific number of tokens from the very end of a string.
+ * This is used to create a "bridge" between two chunks
+ * so the AI doesn't lose the meaning of a sentence cut in half.
+ * * @param {string} text - The source text to pull from.
+ * @param {number} overlapTokens - How many tokens to take from the end.
+ * @returns {string} The last X tokens converted back into text.
+ */
+
+function tailByTokens(text, overlapTokens) {
+  if (!text || overlapTokens <= 0) return "";
+  const tokenizer = getTokenizer();
+  // If the text is shorter than the overlap we want, return the whole thing
+  const ids = tokenizer.encode(text);
+  if (ids.length <= overlapTokens) return text;
+  // Slice the array of IDs to get only the last 'overlapTokens' and decode them
+  return tokenizer.decode(ids.slice(ids.length - overlapTokens));
+}
+/**
+ * Splits a long document into smaller, AI-friendly pieces (chunks).
+ * It splits by paragraphs first to keep thoughts together, then checks 
+ * token counts to ensure each piece fits within the AI's "context window."
+ * * @param {string} text - The full text to be divided.
+ * @param {object} options - Configuration for maxChunkTokens and overlapTokens.
+ * @returns {string[]} An array of text chunks with overlapping ends/starts.
+ */
+
+function chunkTextByTokens(text, options = {}) {
+    // Default limits: 500 tokens per chunk, with 50 tokens of repeated context
+  const maxChunkTokens = options.maxChunkTokens ?? 500;
+  const overlapTokens = options.overlapTokens ?? 50;
+
+  if (!text || !text.trim()) return [];
+
+  const chunks = [];
+  // Split by double newlines to try and preserve paragraph structure
+  const parts = text.split(/\n\n+/); 
+  let current = "";
+  for (const part of parts) {
+    // Create a "test" version of the chunk including the new paragraph
+    const candidate = current ? `${current}\n\n${part}` : part;
+
+    // If the test version is small enough, keep adding to the current bucket
+    if (countTokens(candidate) <= maxChunkTokens) {
+      current = candidate;
+      continue;
+    }
+    // current is full, push it
+    if (current) {
+      chunks.push(current);
+    }
+    // SPECIAL CASE:if single part is too big, hard-truncate and continue
+    if (countTokens(part) > maxChunkTokens) {
+        // Snip it exactly at the limit
+      const clipped = truncateToTokenLimit(part, maxChunkTokens);
+      chunks.push(clipped);
+      // Start the next chunk with the 'tail' (overlap) of what we just cut
+      current = tailByTokens(clipped, overlapTokens); // token overlap
+      continue;
+    }
+    // sNORMAL CASE:tart new chunk with token overlap from previous chunk
+    const overlap = current ? tailByTokens(current, overlapTokens) : "";
+    current = overlap ? `${overlap}\n\n${part}` : part;
+    // safety in case overlap + part exceeds
+    if (countTokens(current) > maxChunkTokens) {
+      current = truncateToTokenLimit(current, maxChunkTokens);
+    }
+  }
+  // If there is any leftover text in the last bucket, save it
+  if (current) {
+    chunks.push(current);
+  }
+  return chunks;
+}
+
+module.exports = { chunkTextByTokens };

--- a/PBL4/StripeBot/backend/src/utils/chunker.js
+++ b/PBL4/StripeBot/backend/src/utils/chunker.js
@@ -16,10 +16,10 @@ const {
 function tailByTokens(text, overlapTokens) {
   if (!text || overlapTokens <= 0) return "";
   const tokenizer = getTokenizer();
-  // If the text is shorter than the overlap we want, return the whole thing
+  // If the text is shorter than the overlap we want, return the whole thing and encode it into tokens
   const ids = tokenizer.encode(text);
   if (ids.length <= overlapTokens) return text;
-  // Slice the array of IDs to get only the last 'overlapTokens' and decode them
+  // Slice the array of IDs to get only the last 'overlapTokens' and decode them into text
   return tokenizer.decode(ids.slice(ids.length - overlapTokens));
 }
 /**
@@ -77,7 +77,7 @@ function chunkTextByTokens(text, options = {}) {
         if (end >= ids.length) break;
       }
 
-      // NORMAL CASE:tart new chunk with token overlap from previous chunk
+      // NORMAL CASE:start new chunk with token overlap from previous chunk
       const overlap = current ? tailByTokens(current, overlapTokens) : "";
       current = overlap ? `${overlap}\n\n${part}` : part;
       // safety in case overlap + part exceeds

--- a/PBL4/StripeBot/backend/src/utils/chunker.js
+++ b/PBL4/StripeBot/backend/src/utils/chunker.js
@@ -24,7 +24,7 @@ function tailByTokens(text, overlapTokens) {
 }
 /**
  * Splits a long document into smaller, AI-friendly pieces (chunks).
- * It splits by paragraphs first to keep thoughts together, then checks 
+ * It splits by paragraphs first to keep thoughts together, then checks
  * token counts to ensure each piece fits within the AI's "context window."
  * * @param {string} text - The full text to be divided.
  * @param {object} options - Configuration for maxChunkTokens and overlapTokens.
@@ -32,15 +32,24 @@ function tailByTokens(text, overlapTokens) {
  */
 
 function chunkTextByTokens(text, options = {}) {
-    // Default limits: 500 tokens per chunk, with 50 tokens of repeated context
-  const maxChunkTokens = options.maxChunkTokens ?? 500;
-  const overlapTokens = options.overlapTokens ?? 50;
+  // Default limits: 500 tokens per chunk, with 50 tokens of repeated context
+  const maxChunkTokensRaw = Number(options.maxChunkTokens ?? 500);
+  const overlapTokensRaw = Number(options.overlapTokens ?? 50);
+
+  const maxChunkTokens =
+    Number.isInteger(maxChunkTokensRaw) && maxChunkTokensRaw > 0
+      ? maxChunkTokensRaw
+      : 500;
+  const overlapTokens =
+    Number.isInteger(overlapTokensRaw) && overlapTokensRaw >= 0
+      ? overlapTokensRaw
+      : 50;
 
   if (!text || !text.trim()) return [];
 
   const chunks = [];
   // Split by double newlines to try and preserve paragraph structure
-  const parts = text.split(/\n\n+/); 
+  const parts = text.split(/\n\n+/);
   let current = "";
   for (const part of parts) {
     // Create a "test" version of the chunk including the new paragraph
@@ -55,28 +64,33 @@ function chunkTextByTokens(text, options = {}) {
     if (current) {
       chunks.push(current);
     }
-    // SPECIAL CASE:if single part is too big, hard-truncate and continue
+    // SPECIAL CASE: single part is too big -> split into multiple token windows
     if (countTokens(part) > maxChunkTokens) {
-        // Snip it exactly at the limit
-      const clipped = truncateToTokenLimit(part, maxChunkTokens);
-      chunks.push(clipped);
-      // Start the next chunk with the 'tail' (overlap) of what we just cut
-      current = tailByTokens(clipped, overlapTokens); // token overlap
-      continue;
+      const tokenizer = getTokenizer();
+      const ids = tokenizer.encode(part);
+      const stride = Math.max(1, maxChunkTokens - Math.max(0, overlapTokens));
+
+      for (let start = 0; start < ids.length; start += stride) {
+        const end = Math.min(start + maxChunkTokens, ids.length);
+        const piece = tokenizer.decode(ids.slice(start, end));
+        chunks.push(piece);
+        if (end >= ids.length) break;
+      }
+
+      // NORMAL CASE:tart new chunk with token overlap from previous chunk
+      const overlap = current ? tailByTokens(current, overlapTokens) : "";
+      current = overlap ? `${overlap}\n\n${part}` : part;
+      // safety in case overlap + part exceeds
+      if (countTokens(current) > maxChunkTokens) {
+        current = truncateToTokenLimit(current, maxChunkTokens);
+      }
     }
-    // sNORMAL CASE:tart new chunk with token overlap from previous chunk
-    const overlap = current ? tailByTokens(current, overlapTokens) : "";
-    current = overlap ? `${overlap}\n\n${part}` : part;
-    // safety in case overlap + part exceeds
-    if (countTokens(current) > maxChunkTokens) {
-      current = truncateToTokenLimit(current, maxChunkTokens);
+    // If there is any leftover text in the last bucket, save it
+    if (current) {
+      chunks.push(current);
     }
+    return chunks;
   }
-  // If there is any leftover text in the last bucket, save it
-  if (current) {
-    chunks.push(current);
-  }
-  return chunks;
 }
 
 module.exports = { chunkTextByTokens };

--- a/PBL4/StripeBot/backend/src/utils/chunker.test.local.js
+++ b/PBL4/StripeBot/backend/src/utils/chunker.test.local.js
@@ -1,0 +1,23 @@
+const { chunkTextByTokens } = require("./chunker");
+const { countTokens } = require("./tokenCounter");
+
+const text = `
+Stripe supports cards, wallets, and bank debits.
+You can create payment intents and confirm them on client or server.
+Webhooks notify your backend for async payment updates.
+Refunds, disputes, and subscriptions are supported as well.
+`.repeat(20); // make it longer
+
+const config = {
+  chunkSizeTokens: 80,
+  chunkOverlapTokens: 10,
+};
+
+const chunks = chunkTextByTokens(text, config);
+
+console.log("Total chunks:", chunks.length);
+
+chunks.forEach((c, i) => {
+  const tokens = countTokens(c);
+  console.log(`Chunk ${i + 1} token count:`, tokens);
+});

--- a/PBL4/StripeBot/backend/src/utils/chunker.test.local.js
+++ b/PBL4/StripeBot/backend/src/utils/chunker.test.local.js
@@ -9,8 +9,8 @@ Refunds, disputes, and subscriptions are supported as well.
 `.repeat(20); // make it longer
 
 const config = {
-  chunkSizeTokens: 80,
-  chunkOverlapTokens: 10,
+  maxChunkTokens: 80,
+  overlapTokens: 10,
 };
 
 const chunks = chunkTextByTokens(text, config);

--- a/PBL4/StripeBot/backend/src/utils/tokenCounter.js
+++ b/PBL4/StripeBot/backend/src/utils/tokenCounter.js
@@ -5,7 +5,7 @@ const TOKENIZER_FALLBACK_ENCODING =
   process.env.TOKENIZER_FALLBACK_ENCODING || "cl100k_base";
 
 let encoder = null;
-
+// getTokenizer() - that returns a tokenizer for the given model.
 function getTokenizer() {
   if (encoder) return encoder;
 

--- a/PBL4/StripeBot/backend/src/utils/tokenCounter.js
+++ b/PBL4/StripeBot/backend/src/utils/tokenCounter.js
@@ -1,0 +1,81 @@
+const { encodingForModel, getEncoding } = require("js-tiktoken");
+
+const TOKENIZER_MODEL = process.env.TOKENIZER_MODEL || "gpt-4o-mini";
+const TOKENIZER_FALLBACK_ENCODING =
+  process.env.TOKENIZER_FALLBACK_ENCODING || "cl100k_base";
+
+let encoder = null;
+
+function getTokenizer() {
+  if (encoder) return encoder;
+
+  try {
+    encoder = encodingForModel(TOKENIZER_MODEL);
+  } catch (error) {
+    console.warn(
+      `[tokenCounter] Model encoding not found for "${TOKENIZER_MODEL}", using fallback "${TOKENIZER_FALLBACK_ENCODING}".`,
+    );
+    encoder = getEncoding(TOKENIZER_FALLBACK_ENCODING);
+  }
+
+  return encoder;
+}
+/*Ensures the input is a valid string, returning an empty string if it's null/undefined.*/
+function safeText(input) {
+  if (input === null || input === undefined) return "";
+  return typeof input === "string" ? input : String(input);
+}
+
+/**
+ * countTokens(text: string): number
+ * Counts the number of tokens (AI word-bites) in a piece of text.
+ * Returns 0 safely for null/undefined/empty input.
+ */
+function countTokens(text) {
+  const value = safeText(text);
+  if (!value.trim()) return 0;
+
+  const tokenizer = getTokenizer();
+  return tokenizer.encode(value).length;
+}
+
+/**
+ * truncateToTokenLimit(text, maxTokens): string
+ * Truncates/cuts off text so token count <= maxTokens.
+ */
+function truncateToTokenLimit(text, maxTokens) {
+  const value = safeText(text);
+  if (!value.trim()) return "";
+  if (!Number.isFinite(maxTokens) || maxTokens <= 0) return "";
+
+  const tokenizer = getTokenizer();
+  const encoded = tokenizer.encode(value);
+
+  if (encoded.length <= maxTokens) return value;
+
+  const truncated = encoded.slice(0, maxTokens);
+  return tokenizer.decode(truncated);
+}
+
+/**
+ * estimateChunkTokenCount(chunk): number
+ * Measures text even if it's hidden inside an object (checks fields like 'content' or 'text').
+ * Supports string chunk or object chunk (common fields).
+ */
+function estimateChunkTokenCount(chunk) {
+  if (chunk === null || chunk === undefined) return 0;
+  if (typeof chunk === "string") return countTokens(chunk);
+
+  // Try common chunk shapes
+  const textCandidate =
+    chunk.text ?? chunk.content ?? chunk.pageContent ?? chunk.chunk ?? "";
+
+  return countTokens(textCandidate);
+}
+
+module.exports = {
+  getTokenizer,
+  countTokens,
+  truncateToTokenLimit,
+  estimateChunkTokenCount,
+};


### PR DESCRIPTION

## Summary

- This PR adds reusable token counting for the StripeBot backend using js-tiktoken, with a configurable model encoding and a safe fallback to cl100k_base when model-specific encoding is unavailable. 
- It introduces a paragraph-oriented chunker that sizes chunks and overlap by token count instead of character length, so chunk boundaries align better with model context limits.


**Linked issues:** Closes #860 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced backend text processing infrastructure to improve data handling and performance

* **Tests**
  * Added local testing utilities for text processing verification

* **Chores**
  * Added required runtime dependencies to support enhanced backend functionality
  * Updated git configuration to exclude environment and temporary files from version control

<!-- end of auto-generated comment: release notes by coderabbit.ai -->