### PR TITLE
Replace plain-text chunking with page-object input

### DIFF
--- a/PBL4/StripeBot/.gitignore
+++ b/PBL4/StripeBot/.gitignore
@@ -1,1 +1,2 @@
 scripts/
+temp/

--- a/PBL4/StripeBot/backend/src/utils/chunker.js
+++ b/PBL4/StripeBot/backend/src/utils/chunker.js
@@ -1,8 +1,4 @@
-const {
-  countTokens,
-  truncateToTokenLimit,
-  getTokenizer,
-} = require("../utils/tokenCounter");
+const { countTokens, getTokenizer } = require("../utils/tokenCounter");
 
 /**
  * Grabs a specific number of tokens from the very end of a string.
@@ -23,74 +19,105 @@ function tailByTokens(text, overlapTokens) {
   return tokenizer.decode(ids.slice(ids.length - overlapTokens));
 }
 /**
- * Splits a long document into smaller, AI-friendly pieces (chunks).
- * It splits by paragraphs first to keep thoughts together, then checks
- * token counts to ensure each piece fits within the AI's "context window."
- * * @param {string} text - The full text to be divided.
- * @param {object} options - Configuration for maxChunkTokens and overlapTokens.
- * @returns {string[]} An array of text chunks with overlapping ends/starts.
+ * Chunks a single scraped page object.
+ * @param {Object} pageObject - One item from the scraped JSON array
+ * @param {object} options - { maxChunkTokens, overlapTokens }
+ * @returns {Object[]} Array of DB-ready chunk objects
  */
 
-function chunkTextByTokens(text, options = {}) {
-  // Default limits: 500 tokens per chunk, with 50 tokens of repeated context
-  const maxChunkTokensRaw = Number(options.maxChunkTokens ?? 500);
-  const overlapTokensRaw = Number(options.overlapTokens ?? 50);
+function chunkPageObject(pageObject, options = {}) {
+  const maxChunkTokens = options.maxChunkTokens || 800;
+  const overlapTokens = options.overlapTokens || 100;
 
-  const maxChunkTokens =
-    Number.isInteger(maxChunkTokensRaw) && maxChunkTokensRaw > 0
-      ? maxChunkTokensRaw
-      : 500;
-  const overlapTokens =
-    Number.isInteger(overlapTokensRaw) && overlapTokensRaw >= 0
-      ? overlapTokensRaw
-      : 50;
+  const {
+    content,
+    id,
+    url,
+    category,
+    title,
+    scrapedAt,
+    docType,
+    metadata: sourceMetadata,
+  } = pageObject;
 
-  if (!text || !text.trim()) return [];
+  if (!content || !content.trim()) return [];
+
+  // Metadata to carry into every chunk from this page
+  const docMetadata = {
+    source_id: id,
+    url,
+    category,
+    title,
+    docType,
+    scrapedAt,
+    source: sourceMetadata?.source,
+    contentType: sourceMetadata?.contentType,
+  };
 
   const chunks = [];
-  // Split by double newlines to try and preserve paragraph structure
-  const parts = text.split(/\n\n+/);
+  const tokenizer = getTokenizer();
+
+  const createChunkObject = (chunkContent) => ({
+    content: chunkContent,
+    metadata: {
+      ...docMetadata,
+      chunk_index: chunks.length,
+      token_count: countTokens(chunkContent),
+    },
+  });
+
+  const parts = content.split(/\n\n+/);
   let current = "";
+
   for (const part of parts) {
-    // Create a "test" version of the chunk including the new paragraph
     const candidate = current ? `${current}\n\n${part}` : part;
 
-    // If the test version is small enough, keep adding to the current bucket
     if (countTokens(candidate) <= maxChunkTokens) {
       current = candidate;
       continue;
     }
-    // current is full, push it
+
     if (current) {
-      chunks.push(current);
+      chunks.push(createChunkObject(current));
     }
-    // SPECIAL CASE: single part is too big -> split into multiple token windows
+
     if (countTokens(part) > maxChunkTokens) {
-      const tokenizer = getTokenizer();
       const ids = tokenizer.encode(part);
-      const stride = Math.max(1, maxChunkTokens - Math.max(0, overlapTokens));
+      const stride = Math.max(1, maxChunkTokens - overlapTokens);
 
       for (let start = 0; start < ids.length; start += stride) {
         const end = Math.min(start + maxChunkTokens, ids.length);
         const piece = tokenizer.decode(ids.slice(start, end));
-        chunks.push(piece);
+        chunks.push(createChunkObject(piece));
         if (end >= ids.length) break;
       }
 
-      // NORMAL CASE:start new chunk with token overlap from previous chunk
-      const overlap = current ? tailByTokens(current, overlapTokens) : "";
-      current = overlap ? `${overlap}\n\n${part}` : part;
-      // safety in case overlap + part exceeds
-      if (countTokens(current) > maxChunkTokens) {
-        current = truncateToTokenLimit(current, maxChunkTokens);
-      }
+      // Fix: carry overlap after force-split (was missing before)
+      const lastPiece = chunks[chunks.length - 1].content;
+      current = tailByTokens(lastPiece, overlapTokens);
+    } else {
+      const overlapText = current ? tailByTokens(current, overlapTokens) : "";
+      current = overlapText ? `${overlapText}\n\n${part}` : part;
     }
-    // If there is any leftover text in the last bucket, save it
-    if (current) {
-      chunks.push(current);
-    }
-    return chunks;
   }
+
+  if (current) {
+    chunks.push(createChunkObject(current));
+  }
+
+  return chunks;
 }
 
-module.exports = { chunkTextByTokens };
+/**
+ * Processes the full scraped JSON array.
+ * @param {Object[]} scrapedPages - The array your teammate produces
+ * @param {object} options - { maxChunkTokens, overlapTokens }
+ * @returns {Object[]} Flat array of all DB-ready chunks across all pages
+ */
+function chunkScrapedJSON(scrapedPages, options = {}) {
+  if (!Array.isArray(scrapedPages) || scrapedPages.length === 0) return [];
+
+  return scrapedPages.flatMap((page) => chunkPageObject(page, options));
+}
+
+module.exports = { chunkScrapedJSON, chunkPageObject };

--- a/PBL4/StripeBot/backend/src/utils/chunker.test.local.js
+++ b/PBL4/StripeBot/backend/src/utils/chunker.test.local.js
@@ -1,23 +1,178 @@
-const { chunkTextByTokens } = require("./chunker");
+const { chunkScrapedJSON, chunkPageObject } = require("./chunker");
 const { countTokens } = require("./tokenCounter");
 
-const text = `
+// Mocked scraped JSON — mimics your teammate's output
+const scrapedPages = [
+  {
+    id: "api_001",
+    url: "https://stripe.com/docs/api",
+    category: "api",
+    title: "API Reference",
+    docType: "api",
+    scrapedAt: new Date().toISOString(),
+    wordCount: 300,
+    content: `
 Stripe supports cards, wallets, and bank debits.
 You can create payment intents and confirm them on client or server.
 Webhooks notify your backend for async payment updates.
 Refunds, disputes, and subscriptions are supported as well.
-`.repeat(20); // make it longer
+    `.repeat(20),
+    metadata: {
+      source: "stripe.com",
+      contentType: "text/html; charset=utf-8",
+    },
+  },
+  {
+    id: "api_002",
+    url: "https://stripe.com/docs/payments",
+    category: "payments",
+    title: "Payments Guide",
+    docType: "guide",
+    scrapedAt: new Date().toISOString(),
+    wordCount: 150,
+    content: `
+Authentication uses API keys with sk_test_ and sk_live_ prefixes.
+All requests must be made over HTTPS.
+Test mode does not affect live data.
+    `.repeat(10),
+    metadata: {
+      source: "stripe.com",
+      contentType: "text/html; charset=utf-8",
+    },
+  },
+  // Edge case: empty content
+  {
+    id: "api_003",
+    url: "https://stripe.com/docs/empty",
+    category: "misc",
+    title: "Empty Page",
+    docType: "guide",
+    scrapedAt: new Date().toISOString(),
+    wordCount: 0,
+    content: "",
+    metadata: {
+      source: "stripe.com",
+      contentType: "text/html; charset=utf-8",
+    },
+  },
+];
 
 const config = {
   maxChunkTokens: 80,
   overlapTokens: 10,
 };
 
-const chunks = chunkTextByTokens(text, config);
+// ── Test 1: Full array ────────────────────────────────────────────────────────
+console.log("═══════════════════════════════════════");
+console.log("TEST 1: chunkScrapedJSON (full array)");
+console.log("═══════════════════════════════════════");
 
-console.log("Total chunks:", chunks.length);
+const allChunks = chunkScrapedJSON(scrapedPages, config);
 
-chunks.forEach((c, i) => {
-  const tokens = countTokens(c);
-  console.log(`Chunk ${i + 1} token count:`, tokens);
+console.log("Total chunks across all pages:", allChunks.length);
+console.log("");
+
+// Group chunks by source_id and print summary per page
+const grouped = allChunks.reduce((acc, chunk) => {
+  const key = chunk.metadata.source_id;
+  if (!acc[key]) acc[key] = [];
+  acc[key].push(chunk);
+  return acc;
+}, {});
+
+Object.entries(grouped).forEach(([sourceId, chunks]) => {
+  console.log(`Page: ${sourceId} → ${chunks.length} chunks`);
+  chunks.forEach((c) => {
+    console.log(
+      `  Chunk ${c.metadata.chunk_index + 1} | tokens: ${c.metadata.token_count} | title: ${c.metadata.title}`,
+    );
+  });
 });
+
+// ── Test 2: Single page object ────────────────────────────────────────────────
+console.log("");
+console.log("═══════════════════════════════════════");
+console.log("TEST 2: chunkPageObject (single page)");
+console.log("═══════════════════════════════════════");
+
+const singleChunks = chunkPageObject(scrapedPages[0], config);
+console.log("Chunks for api_001:", singleChunks.length);
+singleChunks.forEach((c, i) => {
+  console.log(`  Chunk ${i + 1} | tokens: ${c.metadata.token_count}`);
+});
+
+// ── Test 3: Metadata integrity check ─────────────────────────────────────────
+console.log("");
+console.log("═══════════════════════════════════════");
+console.log("TEST 3: Metadata integrity");
+console.log("═══════════════════════════════════════");
+
+const firstChunk = allChunks[0];
+const requiredFields = [
+  "source_id",
+  "url",
+  "category",
+  "title",
+  "docType",
+  "scrapedAt",
+  "chunk_index",
+  "token_count",
+];
+
+requiredFields.forEach((field) => {
+  const present = firstChunk.metadata[field] !== undefined;
+  console.log(`  ${present ? "✓" : "✗"} ${field}:`, firstChunk.metadata[field]);
+});
+
+// ── Test 4: Token limit check ─────────────────────────────────────────────────
+console.log("");
+console.log("═══════════════════════════════════════");
+console.log("TEST 4: Token limit violations");
+console.log("═══════════════════════════════════════");
+
+let violations = 0;
+allChunks.forEach((c) => {
+  const actual = countTokens(c.content);
+  // Allow slight overflow on force-split edge cases
+  if (actual > config.maxChunkTokens + 10) {
+    console.log(
+      `  ✗ Chunk ${c.metadata.chunk_index} of ${c.metadata.source_id} has ${actual} tokens (limit: ${config.maxChunkTokens})`,
+    );
+    violations++;
+  }
+});
+console.log(
+  violations === 0
+    ? "  ✓ All chunks within token limit"
+    : `  ${violations} violation(s) found`,
+);
+
+// ── Test 5: Edge cases ────────────────────────────────────────────────────────
+console.log("");
+console.log("═══════════════════════════════════════");
+console.log("TEST 5: Edge cases");
+console.log("═══════════════════════════════════════");
+
+// Empty content page
+const emptyResult = chunkPageObject(scrapedPages[2], config);
+console.log(
+  "  Empty content → chunks:",
+  emptyResult.length,
+  emptyResult.length === 0 ? "✓" : "✗",
+);
+
+// Empty array
+const emptyArray = chunkScrapedJSON([], config);
+console.log(
+  "  Empty array   → chunks:",
+  emptyArray.length,
+  emptyArray.length === 0 ? "✓" : "✗",
+);
+
+// Null/undefined guard
+const nullResult = chunkScrapedJSON(null, config);
+console.log(
+  "  Null input    → chunks:",
+  nullResult.length,
+  nullResult.length === 0 ? "✓" : "✗",
+);


### PR DESCRIPTION
## Summary

Chunking now runs on scraped page objects (JSON) instead of a single plain string. 

**Linked issues:** Closes #866 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured content chunking system to preserve metadata (title, category, URL) with each processed chunk and improve handling of large documents.

* **Tests**
  * Updated test coverage for refactored chunking functionality with edge-case validation.

* **Chores**
  * Updated project ignore patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->