### PR TITLE
feat(stripebot-backend): hybrid RAG pipeline (scrape, chunk, ingest, search, connect to vectorDB)

### DIFF
--- a/PBL4/StripeBot/backend/.gitignore
+++ b/PBL4/StripeBot/backend/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
+data/
 .env

--- a/PBL4/StripeBot/backend/PROJECT.md
+++ b/PBL4/StripeBot/backend/PROJECT.md
@@ -1,0 +1,116 @@
+# StripeBot Backend — Project documentation
+
+This document explains **what this service is**, **why it matters**, and how to think about it during design reviews, handoffs, and production hardening. It complements the operational **[README.md](./README.md)**.
+
+---
+
+## What this project is
+
+**StripeBot backend** is a small **retrieval layer** for a Stripe-focused support or developer assistant:
+
+1. It **collects** public Stripe documentation text (fixed seed URLs today).
+2. It **chunks** that text for retrieval quality (pluggable chunking in `testChunk.js`).
+3. It **embeds** chunks locally with a compact transformer model and **stores** them in **Supabase Postgres** with **pgvector**.
+4. It **answers retrieval queries** with **hybrid search**: classic **full-text (keyword)** ranking plus **dense vector (semantic)** similarity, combined with **reciprocal rank fusion (RRF)** so neither signal dominates by default.
+
+The HTTP API exposes **health** and **hybrid search**; a separate chat/LLM layer (if any) would sit **upstream** and use these chunks as **grounded context** (RAG).
+
+---
+
+## Why it matters
+
+| Stakeholder concern | How this backend helps |
+|---------------------|-------------------------|
+| **Accurate answers** | Retrieval is grounded in scraped doc text, not model hallucination alone. |
+| **Keyword-heavy queries** | Users often paste error codes, endpoint names, or exact phrases — **FTS** handles those well. |
+| **Paraphrases / concepts** | **Embeddings** help when wording differs from the docs. |
+| **Single datastore** | Supabase gives **one** managed Postgres: metadata, vectors, and keyword index — fewer moving parts than Postgres + separate vector SaaS for a class project or MVP. |
+| **Team velocity** | Clear stages (scrape → chunk → ingest → query) map to separate tasks and ownership (e.g. colleague-owned chunking). |
+
+---
+
+## Scope (in / out)
+
+**In scope today**
+
+- Scrape a **curated list** of Stripe documentation entry pages.
+- Persist **chunk-level** rows with **384-dimensional** embeddings aligned to `Xenova/all-MiniLM-L6-v2`.
+- **Hybrid retrieval** API for downstream RAG or demos.
+
+**Explicitly out of scope (unless added later)**
+
+- **Full-site crawl** or sitemap-driven discovery (would increase coverage and ops burden).
+- **LLM answer generation** in this repo (only retrieval is implemented here).
+- **Auth / multi-tenant** isolation (not modeled in `stripe_doc_chunks` yet).
+- **Playwright** rendering (only static HTML from `fetch` + Cheerio).
+
+Document those gaps in planning so expectations stay aligned with stakeholders.
+
+---
+
+## Architectural principles
+
+1. **Separation of concerns** — Scrape, chunk, embed, and serve are separate entrypoints; `npm run dev` does not silently re-ingest.
+2. **Swappable chunking** — `src/scripts/testChunk.js` is the agreed extension point so chunking strategy can change without rewriting ingest.
+3. **Schema matches model** — `vector(384)` and the embedding pipeline must stay in lockstep; changing model dimension requires a **migration** and **re-ingest**.
+4. **Hybrid by default** — Keyword-only and vector-only both fail on different query types; RRF is a simple, explainable fusion baseline.
+
+---
+
+## Dependencies and responsibilities
+
+| Dependency | Role | Operational note |
+|------------|------|------------------|
+| **Supabase (Postgres)** | System of record for chunks + vectors + FTS | Requires SSL; credentials are secrets. |
+| **pg / pgvector** | Typed access to `vector` columns | `db.js` registers the vector type on pool connect. |
+| **@xenova/transformers** | Local CPU embeddings | First run downloads weights; cold start is slow. |
+| **cheerio + undici** | Scrape HTML without a browser | JS-rendered-only content will not appear. |
+| **Express** | Thin API surface | Keep routes small; push logic into services. |
+
+---
+
+## Security and compliance
+
+- **Never commit `.env`** — database URLs and passwords must stay out of git.
+- **Rotate credentials** if they are exposed (chat, screenshots, CI logs).
+- **Connection strings** with special characters (e.g. `@` in passwords) must be **URL-encoded** when using `DATABASE_URL`.
+- **Scraping** must respect Stripe’s terms, rate limits, and robots rules for anything beyond class/demo use.
+- Scraped text includes **redaction** patterns for key-like substrings in `scraper.js`; do not treat that as a substitute for **never logging real secrets**.
+
+---
+
+## Risks and trade-offs
+
+| Risk | Mitigation / note |
+|------|-------------------|
+| **Thin coverage** | Only seed URLs are scraped; quality improves with more URLs or controlled crawling. |
+| **Ingest time** | Sequential embedding is simple but slow at scale; batch or external embedding API later. |
+| **Model drift** | Upgrading the embedding model invalidates old vectors without re-ingest. |
+| **FTS language** | `english` config may miss optimal behavior for mixed-language content. |
+| **Supabase limits** | Connection limits and disk apply; monitor index build times for HNSW. |
+
+---
+
+## Maintenance checklist (for reviewers)
+
+- [ ] `setup_hybrid.sql` applied to the environment that `.env` points to.
+- [ ] `npm run test:chunk` passes after scrape changes.
+- [ ] Ingest completes without dimension / cast errors (384-d).
+- [ ] `/health` returns OK against production-like DB.
+- [ ] Sample `/api/rag/search` returns sensible mix of keyword + semantic hits on known queries.
+
+---
+
+## Handoff notes
+
+- **Chunking owner**: replace logic inside `testChunk.js` while preserving exports used by `ingestVectors.js` (`chunkScrapedDocuments`, etc.) unless ingest is updated in the same change.
+- **Frontend / chat**: consume `POST /api/rag/search` and pass `results[].content` (and citations from `sourceUrl` / `title`) into the LLM prompt.
+
+---
+
+## Document map
+
+| File | Audience |
+|------|----------|
+| [README.md](./README.md) | Anyone running or integrating the backend |
+| **PROJECT.md** (this file) | Tech leads, reviewers, new teammates |

--- a/PBL4/StripeBot/backend/README.md
+++ b/PBL4/StripeBot/backend/README.md
@@ -1,0 +1,184 @@
+# StripeBot — Backend
+
+Hybrid RAG backend: scrape Stripe docs → chunk → embed → **Supabase (Postgres + pgvector)** → keyword + semantic search with fusion.
+
+For **why this exists**, scope, and trade-offs, see **[PROJECT.md](./PROJECT.md)**.
+
+---
+
+## Pipeline overview
+
+```mermaid
+flowchart LR
+  subgraph collect
+    A[Stripe doc URLs] --> B[scraper.js]
+    B --> C[scraped.json]
+  end
+  subgraph prepare
+    C --> D[testChunk.js]
+    D --> E[Text chunks]
+  end
+  subgraph embed_store
+    E --> F[embeddingService.js]
+    F --> G[384-d vectors]
+    G --> H[(Supabase Postgres)]
+    H --> I[stripe_doc_chunks]
+    I --> J[content_tsv / FTS]
+    I --> K[embedding / HNSW]
+  end
+  subgraph query
+    Q[User query] --> L[hybridRagService.js]
+    L --> J
+    L --> K
+    L --> M[RRF fusion]
+    M --> N[Ranked chunks]
+  end
+```
+
+### Commands vs flow
+
+```mermaid
+flowchart TB
+  subgraph npm
+    scrape[npm run scrape]
+    testchunk[npm run test:chunk]
+    ingest[npm run ingest]
+    refresh[npm run data:refresh]
+    dev[npm run dev]
+  end
+  scrape --> JSON[data/stripe_docs/scraped.json]
+  JSON --> testchunk
+  JSON --> ingest
+  scrape --> refresh
+  refresh --> ingest
+  ingest --> DB[(Supabase)]
+  dev --> API[Express src/app.js]
+  API --> hybrid[hybridRagService]
+  hybrid --> DB
+```
+
+### Hybrid retrieval (keyword + semantic)
+
+```mermaid
+flowchart TB
+  Q[Query text] --> E[Embed query]
+  Q --> FTS[FTS: plainto_tsquery + ts_rank_cd]
+  E --> VEC[Vector: cosine via embedding <=> query]
+  FTS --> L1[Top-K keyword rows]
+  VEC --> L2[Top-K semantic rows]
+  L1 --> RRF[RRF merge]
+  L2 --> RRF
+  RRF --> OUT[Final ranked chunks]
+```
+
+---
+
+## Quick start
+
+1. **Install**
+
+   ```bash
+   cd PBL4/StripeBot/backend
+   npm install
+   ```
+
+2. **Configure** — copy `.env.example` if you maintain one, or set:
+
+   - `DATABASE_URL` *or* `PGHOST`, `PGPORT`, `PGDATABASE`, `PGUSER`, `PGPASSWORD`
+   - Optional scrape tuning: `RATE_LIMIT_DELAY`, `SCRAPE_FETCH_TIMEOUT_MS`, `SCRAPE_USER_AGENT`
+
+3. **Database** — in Supabase **SQL Editor**, run:
+
+   [`src/sql/setup_hybrid.sql`](./src/sql/setup_hybrid.sql)
+
+   This creates `stripe_doc_chunks` (vectors + generated `tsvector` + indexes).
+
+4. **Scrape → ingest → run API**
+
+   ```bash
+   npm run scrape
+   npm run test:chunk    # optional sanity check
+   npm run ingest        # first run downloads the embedding model (slow)
+   npm run dev
+   ```
+
+   Or one shot (scrape + ingest, not the server):
+
+   ```bash
+   npm run data:refresh
+   ```
+
+---
+
+## NPM scripts
+
+| Script | Purpose |
+|--------|---------|
+| `npm run scrape` | Fetch listed Stripe URLs → `data/stripe_docs/scraped.json` |
+| `npm run test:chunk` | Read `scraped.json`, print chunk count (validates `testChunk.js`) |
+| `npm run ingest` | Chunk → embed → upsert `stripe_doc_chunks` |
+| `npm run data:refresh` | `scrape` then `ingest` |
+| `npm run dev` | Express API (nodemon) |
+| `npm start` | Express API (no watch) |
+
+**Note:** `dev` does **not** auto-scrape or auto-ingest on boot (avoids accidental full re-runs).
+
+---
+
+## API
+
+| Method | Path | Body / notes |
+|--------|------|----------------|
+| `GET` | `/health` | DB connectivity check |
+| `POST` | `/api/rag/search` | `{ "query": "string", "keywordLimit"?, "semanticLimit"?, "finalLimit"? }` |
+
+Example:
+
+```bash
+curl -s -X POST http://localhost:3000/api/rag/search \
+  -H "Content-Type: application/json" \
+  -d '{"query":"webhook signature","finalLimit":5}'
+```
+
+Default port: `3000` (override with `PORT`).
+
+---
+
+## Key files
+
+| Path | Role |
+|------|------|
+| `src/scripts/scraper.js` | HTTP fetch + Cheerio → `scraped.json` |
+| `src/scripts/testChunk.js` | Chunking (swap-friendly for teammate) |
+| `src/scripts/ingestVectors.js` | JSON → chunks → embeddings → DB |
+| `src/services/embeddingService.js` | `Xenova/all-MiniLM-L6-v2` (384-d) |
+| `src/services/hybridRagService.js` | FTS + vector search + RRF |
+| `src/config/db.js` | `pg` pool + `pgvector` registration |
+| `src/app.js` | Express entry |
+| `src/sql/setup_hybrid.sql` | Schema for hybrid RAG |
+
+Legacy: `src/sql/setup.sql` targets an older `stripe_docs` table; **hybrid flow uses `setup_hybrid.sql` only**.
+
+---
+
+## Ingest behavior
+
+- Default: **truncates** `stripe_doc_chunks` before load. Set `INGEST_APPEND=1` to skip truncate (upsert only).
+- Chunk size / overlap: `CHUNK_MAX_CHARS`, `CHUNK_OVERLAP` (see `testChunk.js`).
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---------|----------------|
+| `relation "stripe_doc_chunks" does not exist` | Run `setup_hybrid.sql` on the **same** DB as `.env`. |
+| `Headers is not defined` (transformers) | Should be mitigated via undici polyfill in `embeddingService.js`; use Node 18+ if issues persist. |
+| Empty keyword hits | Query terms are stopwords or not in indexed text; try different phrasing. |
+| Scrape flags ignored with npm | Use `npm run scrape -- --sources=api --limit=1` (note `--` before script args). |
+
+---
+
+## Related doc
+
+- **[PROJECT.md](./PROJECT.md)** — product context, importance, scope, risks, and maintenance notes.

--- a/PBL4/StripeBot/backend/package.json
+++ b/PBL4/StripeBot/backend/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "scrape": "node scripts/scraper.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],
@@ -14,6 +15,8 @@
     "@langchain/core": "^1.1.38",
     "js-tiktoken": "^1.0.21",
     "nvm": "^0.0.4",
-    "use": "^3.1.1"
+    "use": "^3.1.1",
+    "cheerio": "1.0.0-rc.12",
+    "undici": "^5.28.4"
   }
 }

--- a/PBL4/StripeBot/backend/package.json
+++ b/PBL4/StripeBot/backend/package.json
@@ -2,10 +2,16 @@
   "name": "backend",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "src/app.js",
+  "type": "module",
   "scripts": {
-    "scrape": "node scripts/scraper.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "scrape": "node src/scripts/scraper.js",
+    "test:chunk": "node src/scripts/testChunk.js",
+    "ingest": "node src/scripts/ingestVectors.js",
+    "data:refresh": "npm run scrape && npm run ingest",
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node src/app.js",
+    "dev": "nodemon src/app.js"
   },
   "keywords": [],
   "author": "",
@@ -16,7 +22,15 @@
     "js-tiktoken": "^1.0.21",
     "nvm": "^0.0.4",
     "use": "^3.1.1",
+    "@xenova/transformers": "^2.17.2",
     "cheerio": "1.0.0-rc.12",
+    "dotenv": "^17.4.0",
+    "express": "^5.2.1",
+    "pg": "^8.20.0",
+    "pgvector": "^0.2.1",
     "undici": "^5.28.4"
+  },
+  "devDependencies": {
+    "nodemon": "^3.1.14"
   }
 }

--- a/PBL4/StripeBot/backend/scripts/scraper.js
+++ b/PBL4/StripeBot/backend/scripts/scraper.js
@@ -1,0 +1,230 @@
+import * as cheerio from "cheerio";
+import fs from "fs/promises";
+import path from "path";
+import { fetch } from "undici";
+
+/** Stripe documentation entry points (same set as StripeCustomerSupportAgent reference). */
+export const SOURCES = {
+  api: "https://stripe.com/docs/api",
+  webhooks: "https://stripe.com/docs/webhooks",
+  errors: "https://stripe.com/docs/error-codes",
+  payments: "https://stripe.com/docs/payments/payment-methods",
+  billing: "https://stripe.com/docs/billing",
+  disputes: "https://stripe.com/docs/disputes",
+  integration: "https://stripe.com/docs/development/get-started",
+  support: "https://support.stripe.com/topics",
+  connect: "https://stripe.com/docs/connect",
+};
+
+const DEFAULT_USER_AGENT =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36";
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function rateLimitMs() {
+  const raw = process.env.RATE_LIMIT_DELAY;
+  const n = raw ? parseInt(raw, 10) : NaN;
+  return Number.isFinite(n) && n >= 0 ? n : 1000;
+}
+
+function fetchTimeoutMs() {
+  const raw = process.env.SCRAPE_FETCH_TIMEOUT_MS;
+  const n = raw ? parseInt(raw, 10) : NaN;
+  return Number.isFinite(n) && n > 0 ? n : 30_000;
+}
+
+/** Abort fetch after ms (Node 16–compatible; avoids AbortSignal.timeout). */
+function abortAfter(ms) {
+  const controller = new AbortController();
+  const id = setTimeout(() => controller.abort(), ms);
+  const signal = controller.signal;
+  return { signal, cancel: () => clearTimeout(id) };
+}
+
+/**
+ * Fetch HTML with native fetch (no axios).
+ * @param {string} url
+ * @returns {Promise<{ html: string, contentType: string }>}
+ */
+async function fetchHtml(url) {
+  const { signal, cancel } = abortAfter(fetchTimeoutMs());
+  let res;
+  try {
+    res = await fetch(url, {
+      headers: {
+        "User-Agent": process.env.SCRAPE_USER_AGENT || DEFAULT_USER_AGENT,
+        Accept: "text/html,application/xhtml+xml",
+      },
+      signal,
+    });
+  } finally {
+    cancel();
+  }
+
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status} ${res.statusText}`);
+  }
+
+  const html = await res.text();
+  const contentType = res.headers.get("content-type") || "text/html";
+  return { html, contentType };
+}
+
+/**
+ * Scrape a single Stripe docs URL into a plain document object (JSON-serializable).
+ * @param {string} url
+ * @param {string} category
+ */
+export async function scrapeDoc(url, category) {
+  console.log(`🔍 Scraping ${category}: ${url}`);
+
+  try {
+    await delay(rateLimitMs());
+
+    const { html, contentType } = await fetchHtml(url);
+    const $ = cheerio.load(html);
+
+    $(
+      "nav, footer, .sidebar, .header, .advertisement, .cookie-banner, script, style"
+    ).remove();
+
+    const content =
+      $("main").text() || $("article").text() || $("body").text();
+
+    let title = "";
+    if ($("h1").length > 0) {
+      title = $("h1").first().text().trim();
+    } else if ($("title").length > 0) {
+      title = $("title").text().trim();
+    } else if ($("h2").length > 0) {
+      title = $("h2").first().text().trim();
+    } else if ($(".page-title").length > 0) {
+      title = $(".page-title").first().text().trim();
+    } else if ($("[data-testid='page-title']").length > 0) {
+      title = $("[data-testid='page-title']").first().text().trim();
+    }
+
+    title = title
+      .replace(/\s+/g, " ")
+      .replace(/^\s*-\s*Stripe\s*$/, "")
+      .replace(/^\s*Stripe\s*-\s*/, "")
+      .trim();
+
+    if (!title) {
+      const categoryTitles = {
+        api: "API Reference",
+        webhooks: "Webhooks",
+        errors: "Error Codes",
+        payments: "Payment Methods",
+        billing: "Billing",
+        disputes: "Disputes",
+        integration: "Integration Guide",
+        support: "Support",
+        connect: "Connect",
+      };
+      title = categoryTitles[category] || "Documentation";
+    }
+
+    const cleanContent = content
+      .replace(/\s+/g, " ")
+      .replace(/sk_test_[A-Za-z0-9]+/g, "sk_test_[REDACTED]")
+      .replace(/sk_live_[A-Za-z0-9]+/g, "sk_live_[REDACTED]")
+      .replace(/whsec_[A-Za-z0-9]+/g, "whsec_[REDACTED]")
+      .replace(/pk_test_[A-Za-z0-9]+/g, "pk_test_[REDACTED]")
+      .replace(/pk_live_[A-Za-z0-9]+/g, "pk_live_[REDACTED]")
+      .trim();
+
+    const wordCount = cleanContent.split(/\s+/).filter(Boolean).length;
+
+    return {
+      id: `${category}_${Date.now()}`,
+      url,
+      category,
+      title: title.trim(),
+      content: cleanContent,
+      wordCount,
+      scrapedAt: new Date().toISOString(),
+      docType: "api",
+      metadata: {
+        source: "stripe.com",
+        contentType,
+      },
+    };
+  } catch (error) {
+    console.error(`❌ Error scraping ${category}:`, error.message);
+    return null;
+  }
+}
+
+async function writeScrapedJson(docs) {
+  const outputDir = path.join(process.cwd(), "data", "stripe_docs");
+  await fs.mkdir(outputDir, { recursive: true });
+  const outputFile = path.join(outputDir, "scraped.json");
+  await fs.writeFile(outputFile, JSON.stringify(docs, null, 2), "utf8");
+  console.log(`💾 Saved ${docs.length} document(s) to: ${outputFile}`);
+  return outputFile;
+}
+
+async function main() {
+  console.log("🚀 Starting Stripe documentation scraper (fetch + cheerio, JSON output only)…");
+
+  const args = process.argv.slice(2);
+  const sourcesArg = args
+    .find((arg) => arg.startsWith("--sources="))
+    ?.split("=")[1];
+  const limitArg = args
+    .find((arg) => arg.startsWith("--limit="))
+    ?.split("=")[1];
+
+  let sourcesToScrape = Object.keys(SOURCES);
+  const limit = limitArg ? parseInt(limitArg, 10) : null;
+
+  if (sourcesArg) {
+    if (sourcesArg === "all") {
+      sourcesToScrape = Object.keys(SOURCES);
+    } else {
+      sourcesToScrape = sourcesArg.split(",").map((s) => s.trim());
+    }
+  }
+
+  console.log(`📋 Sources: ${sourcesToScrape.join(", ")}`);
+  if (limit) console.log(`🔢 Limit: ${limit} document(s) total`);
+
+  const docs = [];
+  let totalWords = 0;
+
+  for (const category of sourcesToScrape) {
+    if (!SOURCES[category]) {
+      console.log(`⚠️ Unknown source: ${category}`);
+      continue;
+    }
+
+    const doc = await scrapeDoc(SOURCES[category], category);
+    if (doc) {
+      docs.push(doc);
+      totalWords += doc.wordCount;
+      console.log(`✅ Scraped ${category}: ${doc.wordCount} words`);
+    }
+
+    if (limit && docs.length >= limit) {
+      console.log(`🛑 Reached limit of ${limit} document(s)`);
+      break;
+    }
+  }
+
+  await writeScrapedJson(docs);
+
+  console.log(`\n🎉 Scraping completed!`);
+  console.log(`📊 Total documents: ${docs.length}`);
+  console.log(`📝 Total words: ${totalWords.toLocaleString()}`);
+  docs.forEach((doc) => {
+    console.log(`  • ${doc.category}: ${doc.wordCount} words`);
+  });
+}
+
+if (process.argv[1] && process.argv[1].endsWith("scraper.js")) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/PBL4/StripeBot/backend/src/app.js
+++ b/PBL4/StripeBot/backend/src/app.js
@@ -1,0 +1,35 @@
+import "dotenv/config";
+import express from "express";
+import pool from "./config/db.js";
+import { hybridSearch } from "./services/hybridRagService.js";
+
+const app = express();
+app.use(express.json());
+
+app.get("/health", async (req, res) => {
+  try {
+    const r = await pool.query("SELECT NOW() AS now");
+    res.json({ ok: true, db: true, time: r.rows[0].now });
+  } catch (err) {
+    res.status(503).json({ ok: false, db: false, error: err.message });
+  }
+});
+
+app.post("/api/rag/search", async (req, res) => {
+  try {
+    const { query, keywordLimit, semanticLimit, finalLimit } = req.body || {};
+    const out = await hybridSearch(query, {
+      keywordLimit,
+      semanticLimit,
+      finalLimit,
+    });
+    res.json(out);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+const PORT = Number(process.env.PORT) || 3000;
+app.listen(PORT, () => {
+  console.log(`StripeBot API http://localhost:${PORT} (GET /health, POST /api/rag/search)`);
+});

--- a/PBL4/StripeBot/backend/src/config/db.js
+++ b/PBL4/StripeBot/backend/src/config/db.js
@@ -1,0 +1,28 @@
+import pg from "pg";
+import pgvector from "pgvector/pg";
+import "dotenv/config";
+
+const { Pool } = pg;
+
+const ssl = { rejectUnauthorized: false };
+
+const pool = process.env.DATABASE_URL
+  ? new Pool({
+      connectionString: process.env.DATABASE_URL,
+      ssl,
+    })
+  : new Pool({
+      host: process.env.PGHOST,
+      port: Number(process.env.PGPORT),
+      database: process.env.PGDATABASE,
+      user: process.env.PGUSER,
+      password: process.env.PGPASSWORD,
+      ssl,
+    });
+
+// Register vector type so pg knows how to read/write vector columns
+pool.on("connect", async (client) => {
+  await pgvector.registerType(client);
+});
+
+export default pool;

--- a/PBL4/StripeBot/backend/src/config/db.js
+++ b/PBL4/StripeBot/backend/src/config/db.js
@@ -1,13 +1,25 @@
+/**
+ * Database configuration
+ * pg: PostgreSQL client library
+ * pgvector: PostgreSQL vector extension library
+ */
 import pg from "pg";
 import pgvector from "pgvector/pg";
 import "dotenv/config";
 
+/** Pool: PostgreSQL connection pool
+ * open connections to the database
+ */
 const { Pool } = pg;
 
+/** ssl: SSL configuration tells the Postgres client to use TLS-encrypted connections to connect to the database
+ * rejectUnauthorized: false to allow self-signed certificates
+ */
 const ssl = { rejectUnauthorized: false };
 
 const pool = process.env.DATABASE_URL
-  ? new Pool({
+  ? /** if DATABASE_URL is set, use it to connect to the database */
+    new Pool({
       connectionString: process.env.DATABASE_URL,
       ssl,
     })

--- a/PBL4/StripeBot/backend/src/scripts/ingestVectors.js
+++ b/PBL4/StripeBot/backend/src/scripts/ingestVectors.js
@@ -1,0 +1,62 @@
+import "dotenv/config";
+import fs from "fs/promises";
+import path from "path";
+import { toSql } from "pgvector";
+import pool from "../config/db.js";
+import { embedText } from "../services/embeddingService.js";
+import { chunkScrapedDocuments } from "./testChunk.js";
+
+async function main() {
+  const jsonPath = path.join(process.cwd(), "data", "stripe_docs", "scraped.json");
+  const raw = await fs.readFile(jsonPath, "utf8");
+  const docs = JSON.parse(raw);
+  const chunks = chunkScrapedDocuments(docs);
+
+  console.log("📥 Ingest:", docs.length, "doc(s) →", chunks.length, "chunk(s)");
+
+  const client = await pool.connect();
+  try {
+    if (process.env.INGEST_APPEND !== "1") {
+      await client.query("TRUNCATE stripe_doc_chunks RESTART IDENTITY");
+      console.log("🗑️  Truncated stripe_doc_chunks (set INGEST_APPEND=1 to skip)");
+    }
+
+    let n = 0;
+    for (const ch of chunks) {
+      const emb = await embedText(ch.content);
+      await client.query(
+        `INSERT INTO stripe_doc_chunks (source_doc_id, chunk_index, source_url, title, content, embedding, metadata)
+         VALUES ($1, $2, $3, $4, $5, $6::vector, $7::jsonb)
+         ON CONFLICT (source_doc_id, chunk_index) DO UPDATE SET
+           source_url = EXCLUDED.source_url,
+           title = EXCLUDED.title,
+           content = EXCLUDED.content,
+           embedding = EXCLUDED.embedding,
+           metadata = EXCLUDED.metadata`,
+        [
+          ch.sourceDocId,
+          ch.chunkIndex,
+          ch.sourceUrl,
+          ch.title,
+          ch.content,
+          toSql(emb),
+          JSON.stringify({ category: ch.category, ...ch.metadata }),
+        ],
+      );
+      n += 1;
+      if (n % 20 === 0) console.log("   … embedded", n, "/", chunks.length);
+    }
+    console.log("✅ Ingest complete:", n, "row(s) upserted");
+  } finally {
+    client.release();
+  }
+
+  await pool.end();
+}
+
+if (process.argv[1]?.endsWith("ingestVectors.js")) {
+  main().catch((e) => {
+    console.error("❌ Ingest failed:", e.message);
+    process.exit(1);
+  });
+}

--- a/PBL4/StripeBot/backend/src/scripts/ingestVectors.js
+++ b/PBL4/StripeBot/backend/src/scripts/ingestVectors.js
@@ -1,29 +1,56 @@
 import "dotenv/config";
+/** fs: File system module for reading and writing files */
 import fs from "fs/promises";
+/** path: Path module for working with file paths */
 import path from "path";
+/** toSql: function to convert the embedding to a SQL vector */
 import { toSql } from "pgvector";
+/** pool: the database connection pool */
 import pool from "../config/db.js";
+/** embedText: function to embed the text */
 import { embedText } from "../services/embeddingService.js";
+/** chunkScrapedDocuments: function to chunk the scraped documents */
 import { chunkScrapedDocuments } from "./testChunk.js";
 
+/** main: main function to ingest the vectors */
 async function main() {
-  const jsonPath = path.join(process.cwd(), "data", "stripe_docs", "scraped.json");
+  /** jsonPath: the path to the JSON file containing the scraped documents */
+  const jsonPath = path.join(
+    process.cwd(),
+    "data",
+    "stripe_docs",
+    "scraped.json",
+  );
   const raw = await fs.readFile(jsonPath, "utf8");
   const docs = JSON.parse(raw);
   const chunks = chunkScrapedDocuments(docs);
 
   console.log("📥 Ingest:", docs.length, "doc(s) →", chunks.length, "chunk(s)");
 
+  /** client: the database client */
   const client = await pool.connect();
+  /** try: try to ingest the vectors */
   try {
+    /** if INGEST_APPEND is not set to 1, truncate the stripe_doc_chunks table */
     if (process.env.INGEST_APPEND !== "1") {
       await client.query("TRUNCATE stripe_doc_chunks RESTART IDENTITY");
-      console.log("🗑️  Truncated stripe_doc_chunks (set INGEST_APPEND=1 to skip)");
+      console.log(
+        "🗑️  Truncated stripe_doc_chunks (set INGEST_APPEND=1 to skip)",
+      );
     }
-
+    /** n: the number of chunks ingested
+     * for each chunk, embed the text and insert the vector into the database
+     */
     let n = 0;
+    /** go through each chunk produced from scraped.json */
     for (const ch of chunks) {
+      /** embed the text of the chunk */
       const emb = await embedText(ch.content);
+      /** insert the vector into the database
+       * embedding (via toSql(emb) for pgvector), metadata as JSON.
+       * ON CONFLICT (source_doc_id, chunk_index) DO UPDATE SET: if the chunk already exists, update the existing chunk
+       * why update: to keep the chunk up to date with the latest version of the document
+       */
       await client.query(
         `INSERT INTO stripe_doc_chunks (source_doc_id, chunk_index, source_url, title, content, embedding, metadata)
          VALUES ($1, $2, $3, $4, $5, $6::vector, $7::jsonb)
@@ -43,17 +70,22 @@ async function main() {
           JSON.stringify({ category: ch.category, ...ch.metadata }),
         ],
       );
+      /** increment the number of chunks ingested */
       n += 1;
+      /** log the progress every 20 chunks
+       */
       if (n % 20 === 0) console.log("   … embedded", n, "/", chunks.length);
     }
     console.log("✅ Ingest complete:", n, "row(s) upserted");
+    /** release the database client */
   } finally {
     client.release();
   }
-
+  /** end the database connection */
   await pool.end();
 }
 
+/** if the script is run directly, run the main function */
 if (process.argv[1]?.endsWith("ingestVectors.js")) {
   main().catch((e) => {
     console.error("❌ Ingest failed:", e.message);

--- a/PBL4/StripeBot/backend/src/scripts/scraper.js
+++ b/PBL4/StripeBot/backend/src/scripts/scraper.js
@@ -1,3 +1,4 @@
+import "dotenv/config";
 import * as cheerio from "cheerio";
 import fs from "fs/promises";
 import path from "path";
@@ -85,11 +86,10 @@ export async function scrapeDoc(url, category) {
     const $ = cheerio.load(html);
 
     $(
-      "nav, footer, .sidebar, .header, .advertisement, .cookie-banner, script, style"
+      "nav, footer, .sidebar, .header, .advertisement, .cookie-banner, script, style",
     ).remove();
 
-    const content =
-      $("main").text() || $("article").text() || $("body").text();
+    const content = $("main").text() || $("article").text() || $("body").text();
 
     let title = "";
     if ($("h1").length > 0) {
@@ -166,7 +166,9 @@ async function writeScrapedJson(docs) {
 }
 
 async function main() {
-  console.log("🚀 Starting Stripe documentation scraper (fetch + cheerio, JSON output only)…");
+  console.log(
+    "🚀 Starting Stripe documentation scraper (fetch + cheerio, JSON output only)…",
+  );
 
   const args = process.argv.slice(2);
   const sourcesArg = args

--- a/PBL4/StripeBot/backend/src/scripts/scraper.js
+++ b/PBL4/StripeBot/backend/src/scripts/scraper.js
@@ -1,10 +1,21 @@
 import "dotenv/config";
+/**
+ * cheerio: library for parsing HTML to extract data
+ * *: asterisk to import all functions from cheerio
+ */
 import * as cheerio from "cheerio";
+/** fs: File system module for reading and writing files */
 import fs from "fs/promises";
+/** path: Path module for working with file paths */
 import path from "path";
+/** undici: Fetch API for making HTTP requests
+ */
 import { fetch } from "undici";
 
-/** Stripe documentation entry points (same set as StripeCustomerSupportAgent reference). */
+/** Stripe documentation entry points.
+ * sources: from where data is scraped
+ */
+
 export const SOURCES = {
   api: "https://stripe.com/docs/api",
   webhooks: "https://stripe.com/docs/webhooks",
@@ -17,28 +28,61 @@ export const SOURCES = {
   connect: "https://stripe.com/docs/connect",
 };
 
+/** Default user agent for the scraper */
 const DEFAULT_USER_AGENT =
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36";
 
+/** Delay for the scraper
+ * @param {number} ms - The delay in milliseconds
+ * @returns {Promise<void>} - A promise that resolves after the delay
+ * Pause async execution for `ms` milliseconds (non-blocking sleep).
+ * Used with `rateLimitMs()` so we wait between HTTP requests.
+ */
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
+/**
+ * @returns {number} - The rate limit in milliseconds
+ * How long to wait between scrape requests (politeness / rate limiting).
+ * Set via env `RATE_LIMIT_DELAY` (milliseconds). Invalid or missing → 1000.
+ * 1000ms is the default rate limit
+ */
 function rateLimitMs() {
   const raw = process.env.RATE_LIMIT_DELAY;
+  /** parseInt: convert the string to a number
+   */
   const n = raw ? parseInt(raw, 10) : NaN;
   return Number.isFinite(n) && n >= 0 ? n : 1000;
 }
-
+/**
+ * Max time to wait for one HTTP response before aborting the fetch.
+ * Env `SCRAPE_FETCH_TIMEOUT_MS` (ms). Invalid or missing → 30000.
+ * @returns {number}
+ */
 function fetchTimeoutMs() {
   const raw = process.env.SCRAPE_FETCH_TIMEOUT_MS;
   const n = raw ? parseInt(raw, 10) : NaN;
   return Number.isFinite(n) && n > 0 ? n : 30_000;
 }
 
-/** Abort fetch after ms (Node 16–compatible; avoids AbortSignal.timeout). */
+/** Abort fetch after ms (Node 16–compatible; avoids AbortSignal.timeout).
+ * Returns an AbortSignal that fires after `ms`, plus a `cancel()` to clear the timer.
+ * Used so `fetch` does not hang forever on slow/broken networks.
+ */
 function abortAfter(ms) {
+  /** AbortController: built-in object used to cancel an async operation (fetch)
+   * creates a controller that can signal "stop" later
+   */
   const controller = new AbortController();
+  /** setTimeout: set a timer to abort the fetch after `ms` */
   const id = setTimeout(() => controller.abort(), ms);
+  /**
+   * signal: a small AbortSignal object pass into fetch(), fetch API listens to that signal
+   * like wire hand to fetch so another part of code can cancel that request
+   */
   const signal = controller.signal;
+  /** cancel: function to clear the timer
+   * id: timer id to clear the timer
+   */
   return { signal, cancel: () => clearTimeout(id) };
 }
 
@@ -80,31 +124,61 @@ export async function scrapeDoc(url, category) {
   console.log(`🔍 Scraping ${category}: ${url}`);
 
   try {
+    /** Space out requests so, do not hammer Stripe (see RATE_LIMIT_DELAY).
+     * wait for the rate limit delay before making the next request
+     *
+     */
     await delay(rateLimitMs());
 
     const { html, contentType } = await fetchHtml(url);
-    const $ = cheerio.load(html);
+    // Load the HTML into cheerio to parse it
+    const parsedHtml = cheerio.load(html);
 
-    $(
+    // Remove navigation, footer, ads, and other non-content elements from the parsed HTML
+    parsedHtml(
       "nav, footer, .sidebar, .header, .advertisement, .cookie-banner, script, style",
     ).remove();
 
-    const content = $("main").text() || $("article").text() || $("body").text();
+    const content =
+      parsedHtml("main").text() ||
+      parsedHtml("article").text() ||
+      parsedHtml("body").text();
 
     let title = "";
-    if ($("h1").length > 0) {
-      title = $("h1").first().text().trim();
-    } else if ($("title").length > 0) {
-      title = $("title").text().trim();
-    } else if ($("h2").length > 0) {
-      title = $("h2").first().text().trim();
-    } else if ($(".page-title").length > 0) {
-      title = $(".page-title").first().text().trim();
-    } else if ($("[data-testid='page-title']").length > 0) {
-      title = $("[data-testid='page-title']").first().text().trim();
+    // Find all <h1> elements in the parsed document.
+    if (parsedHtml("h1").length > 0) {
+      /**
+       * .first(): Take only the first match (in case there are several).
+       * .text():	Get the plain text inside that element (no HTML tags).
+       * .trim():	Remove leading/trailing spaces and line breaks.
+       *  */
+      title = parsedHtml("h1").first().text().trim();
+      /**
+       * in case of no <h1>, you usually get "" (empty string), and the scraper’s later code falls back to other selectors (<title>, h2, etc.) or a default title.
+       */
+    } else if (parsedHtml("title").length > 0) {
+      title = parsedHtml("title").text().trim();
+    } else if (parsedHtml("h2").length > 0) {
+      title = parsedHtml("h2").first().text().trim();
+    } else if (parsedHtml(".page-title").length > 0) {
+      title = parsedHtml(".page-title").first().text().trim();
+      /**
+       * parsedHtml("[data-testid='page-title']"): (Cheerio) selects elements that have HTML attribute data-testid equal to page-title.
+       * why: some pages use data-testid for the title instead of h1, and it's more reliable than h1.
+       */
+    } else if (parsedHtml("[data-testid='page-title']").length > 0) {
+      title = parsedHtml("[data-testid='page-title']").first().text().trim();
     }
 
     title = title
+      /**
+       * /\s+/g with " ": replace every run of whitespace with a single space.
+       * \s: any whitespace (spaces, tabs, newlines, etc.)
+       * +: one or more in a row
+       * g: do it everywhere in the string, not just the first match
+       * " ": replace that whole run with one normal space
+       * e.g.: "Hello world\n\nfoo" → "Hello world foo"
+       */
       .replace(/\s+/g, " ")
       .replace(/^\s*-\s*Stripe\s*$/, "")
       .replace(/^\s*Stripe\s*-\s*/, "")
@@ -125,6 +199,12 @@ export async function scrapeDoc(url, category) {
       title = categoryTitles[category] || "Documentation";
     }
 
+    /**
+     * content: raw text from the page
+     * replace multiple whitespace with single space
+     * replace API keys with [REDACTED] to protect sensitive information
+     * trim leading/trailing spaces and line breaks
+     */
     const cleanContent = content
       .replace(/\s+/g, " ")
       .replace(/sk_test_[A-Za-z0-9]+/g, "sk_test_[REDACTED]")
@@ -156,10 +236,22 @@ export async function scrapeDoc(url, category) {
   }
 }
 
+/**
+ * Write the scraped documents to a JSON file
+ * @param {Object[]} docs - The documents to write
+ * @returns {Promise<string>} - The path to the output file
+ */
 async function writeScrapedJson(docs) {
+  /**
+   * path.join(process.cwd(), "data", "stripe_docs"): join the current working directory with the data/stripe_docs folder
+   */
   const outputDir = path.join(process.cwd(), "data", "stripe_docs");
   await fs.mkdir(outputDir, { recursive: true });
   const outputFile = path.join(outputDir, "scraped.json");
+  /**
+   * JSON.stringify(docs, null, 2): convert the documents to a JSON string
+   * "utf8": the encoding of the output file
+   */
   await fs.writeFile(outputFile, JSON.stringify(docs, null, 2), "utf8");
   console.log(`💾 Saved ${docs.length} document(s) to: ${outputFile}`);
   return outputFile;
@@ -170,6 +262,12 @@ async function main() {
     "🚀 Starting Stripe documentation scraper (fetch + cheerio, JSON output only)…",
   );
 
+  /**
+   * process.argv: an array of command line arguments passed to the script
+   * e.g.: ["node", "path/to/scraper.js", "--sources=api", "--limit=2"]
+   * slice(2): remove the first two arguments (node and the script name)
+   * args: ["--sources=api", "--limit=2"]
+   */
   const args = process.argv.slice(2);
   const sourcesArg = args
     .find((arg) => arg.startsWith("--sources="))
@@ -177,10 +275,17 @@ async function main() {
   const limitArg = args
     .find((arg) => arg.startsWith("--limit="))
     ?.split("=")[1];
-
+  /**
+   * starts as every key in SOURCES (api, webhooks, errors, …).
+   */
   let sourcesToScrape = Object.keys(SOURCES);
+  /**
+   * if limitArg is set, parse it as an integer, otherwise set limit to null
+   * parseInt(limitArg, 10): parse the limit argument as an integer
+   * 10: the radix (base) of the number system to use
+   */
   const limit = limitArg ? parseInt(limitArg, 10) : null;
-
+  /** if sourcesArg is "all", set sourcesToScrape to every key in SOURCES*/
   if (sourcesArg) {
     if (sourcesArg === "all") {
       sourcesToScrape = Object.keys(SOURCES);

--- a/PBL4/StripeBot/backend/src/scripts/testChunk.js
+++ b/PBL4/StripeBot/backend/src/scripts/testChunk.js
@@ -1,0 +1,86 @@
+/**
+ * Chunking for scraped Stripe docs — replace or extend this file when your colleague
+ * lands their chunking logic. Exported API should stay stable for ingest.
+ */
+
+/** @typedef {{ id: string, url: string, category: string, title: string, content: string, scrapedAt?: string, metadata?: object }} ScrapedDoc */
+
+const DEFAULT_MAX_CHARS = Number(process.env.CHUNK_MAX_CHARS) || 800;
+const DEFAULT_OVERLAP = Number(process.env.CHUNK_OVERLAP) || 100;
+
+/**
+ * Split plain text into overlapping windows (character-based; simple & predictable).
+ * @param {string} text
+ * @param {{ maxChars?: number, overlap?: number }} [options]
+ * @returns {string[]}
+ */
+export function chunkText(text, options = {}) {
+  const maxChars = options.maxChars ?? DEFAULT_MAX_CHARS;
+  const overlap = options.overlap ?? DEFAULT_OVERLAP;
+
+  const normalized = String(text || "")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!normalized) return [];
+
+  const chunks = [];
+  let start = 0;
+  while (start < normalized.length) {
+    const end = Math.min(start + maxChars, normalized.length);
+    chunks.push(normalized.slice(start, end).trim());
+    if (end >= normalized.length) break;
+    start = Math.max(0, end - overlap);
+  }
+  return chunks.filter(Boolean);
+}
+
+/**
+ * @param {ScrapedDoc} doc
+ * @param {{ maxChars?: number, overlap?: number }} [options]
+ */
+export function chunkScrapedDocument(doc, options) {
+  const parts = chunkText(doc.content, options);
+  return parts.map((content, chunkIndex) => ({
+    sourceDocId: doc.id,
+    sourceUrl: doc.url,
+    category: doc.category,
+    title: doc.title,
+    chunkIndex,
+    content,
+    metadata: {
+      scrapedAt: doc.scrapedAt,
+      ...(doc.metadata && typeof doc.metadata === "object" ? doc.metadata : {}),
+    },
+  }));
+}
+
+/**
+ * @param {ScrapedDoc[]} docs
+ * @param {{ maxChars?: number, overlap?: number }} [options]
+ */
+export function chunkScrapedDocuments(docs, options) {
+  return docs.flatMap((d) => chunkScrapedDocument(d, options));
+}
+
+async function main() {
+  const path = await import("path");
+  const fs = await import("fs/promises");
+  const jsonPath = path.join(process.cwd(), "data", "stripe_docs", "scraped.json");
+  try {
+    const raw = await fs.readFile(jsonPath, "utf8");
+    const docs = JSON.parse(raw);
+    const chunks = chunkScrapedDocuments(docs);
+    console.log("✅ testChunk: read", docs.length, "scraped doc(s) →", chunks.length, "chunk(s)");
+    if (chunks[0]) {
+      console.log("— sample chunk[0] length:", chunks[0].content.length, "chars");
+    }
+  } catch (e) {
+    console.error("❌ testChunk:", e.message);
+    console.error("   Run from backend root with data/stripe_docs/scraped.json present, or npm run scrape first.");
+    process.exit(1);
+  }
+}
+
+if (process.argv[1]?.endsWith("testChunk.js")) {
+  main();
+}

--- a/PBL4/StripeBot/backend/src/services/embeddingService.js
+++ b/PBL4/StripeBot/backend/src/services/embeddingService.js
@@ -1,4 +1,12 @@
+/** undici: HTTP client for Node.js
+ * use for implement the standard fetch API in Node.js
+ */
 import { fetch, Headers, Request, Response } from "undici";
+/** xenova/transformers: pipeline for feature extraction
+ * @xenova/transformers: JS library to run ML model locally on CPU
+ * Transformers: refers to a type of AI model architecture
+ * pipeline: helper that loads and runs transformer models easily in JavaScript for feature extraction
+ */
 import { pipeline } from "@xenova/transformers";
 
 // @xenova/transformers expects Web APIs (Node < 18)
@@ -7,26 +15,39 @@ if (typeof globalThis.Headers === "undefined") globalThis.Headers = Headers;
 if (typeof globalThis.Request === "undefined") globalThis.Request = Request;
 if (typeof globalThis.Response === "undefined") globalThis.Response = Response;
 
+/**
+ * "Xenova/all-MiniLM-L6-v2": embedding model, converts text → 384-dimensional vector (numbers)
+ * 384 dimension: every sentence is converted into a list of 384 numbers
+ * why: it's a small model that is fast and accurate for feature extraction
+ */
 const MODEL_ID = "Xenova/all-MiniLM-L6-v2";
 
 /** @type {import('@xenova/transformers').FeatureExtractionPipeline | null} */
 let embedder = null;
 
 /**
- * Lazy-load embedding model (384-dim, matches stripe_doc_chunks.embedding).
- * @returns {Promise<number[]>}
+ * embedText: function converts a piece of text into a 384-dimensional embedding vector using an AI model.
+ * return: JavaScript array, length = 384
  */
 export async function embedText(text) {
   if (!embedder) {
     embedder = await pipeline("feature-extraction", MODEL_ID);
   }
   const t = String(text || "").slice(0, 8000);
+  /** embedder: the embedding model
+   * t: processed text input to embed
+   * pooling: "mean": average the embeddings of the tokens to get a single vector
+   * normalize: true: normalize the embedding to have a length of 1
+   */
   const out = await embedder(t, { pooling: "mean", normalize: true });
   const data = out.data;
   return Array.from(data);
 }
 
-/** @param {string[]} texts */
+/** @param {string[]} texts
+ * takes multiple texts and returns multiple embedding vectors
+ * vectors: array of embedding vectors
+ */
 export async function embedTexts(texts) {
   const vectors = [];
   for (const t of texts) {

--- a/PBL4/StripeBot/backend/src/services/embeddingService.js
+++ b/PBL4/StripeBot/backend/src/services/embeddingService.js
@@ -1,0 +1,36 @@
+import { fetch, Headers, Request, Response } from "undici";
+import { pipeline } from "@xenova/transformers";
+
+// @xenova/transformers expects Web APIs (Node < 18)
+if (typeof globalThis.fetch === "undefined") globalThis.fetch = fetch;
+if (typeof globalThis.Headers === "undefined") globalThis.Headers = Headers;
+if (typeof globalThis.Request === "undefined") globalThis.Request = Request;
+if (typeof globalThis.Response === "undefined") globalThis.Response = Response;
+
+const MODEL_ID = "Xenova/all-MiniLM-L6-v2";
+
+/** @type {import('@xenova/transformers').FeatureExtractionPipeline | null} */
+let embedder = null;
+
+/**
+ * Lazy-load embedding model (384-dim, matches stripe_doc_chunks.embedding).
+ * @returns {Promise<number[]>}
+ */
+export async function embedText(text) {
+  if (!embedder) {
+    embedder = await pipeline("feature-extraction", MODEL_ID);
+  }
+  const t = String(text || "").slice(0, 8000);
+  const out = await embedder(t, { pooling: "mean", normalize: true });
+  const data = out.data;
+  return Array.from(data);
+}
+
+/** @param {string[]} texts */
+export async function embedTexts(texts) {
+  const vectors = [];
+  for (const t of texts) {
+    vectors.push(await embedText(t));
+  }
+  return vectors;
+}

--- a/PBL4/StripeBot/backend/src/services/hybridRagService.js
+++ b/PBL4/StripeBot/backend/src/services/hybridRagService.js
@@ -1,0 +1,93 @@
+import { toSql } from "pgvector";
+import pool from "../config/db.js";
+import { embedText } from "./embeddingService.js";
+
+const RRF_K = 60;
+
+/**
+ * Reciprocal Rank Fusion over two ranked lists.
+ * @param {{ id: number }[][]} lists
+ */
+function reciprocalRankFusion(lists, k = RRF_K) {
+  const scores = new Map();
+  for (const list of lists) {
+    list.forEach((row, rank) => {
+      const id = row.id;
+      scores.set(id, (scores.get(id) || 0) + 1 / (k + rank + 1));
+    });
+  }
+  return scores;
+}
+
+/**
+ * Hybrid search: keyword (FTS) + semantic (cosine via pgvector), fused with RRF.
+ * @param {string} query
+ * @param {{ keywordLimit?: number, semanticLimit?: number, finalLimit?: number }} [opts]
+ */
+export async function hybridSearch(query, opts = {}) {
+  const keywordLimit = opts.keywordLimit ?? 15;
+  const semanticLimit = opts.semanticLimit ?? 15;
+  const finalLimit = opts.finalLimit ?? 8;
+
+  const q = String(query || "").trim();
+  if (!q) return { results: [], debug: { error: "empty query" } };
+
+  const [kwRows, queryVec] = await Promise.all([
+    pool.query(
+      `SELECT id, source_url, title, content, chunk_index, source_doc_id,
+              ts_rank_cd(content_tsv, plainto_tsquery('english', $1)) AS kw_rank
+       FROM stripe_doc_chunks
+       WHERE content_tsv @@ plainto_tsquery('english', $1)
+       ORDER BY kw_rank DESC
+       LIMIT $2`,
+      [q, keywordLimit],
+    ),
+    embedText(q),
+  ]);
+
+  const semRes = await pool.query(
+    `SELECT id, source_url, title, content, chunk_index, source_doc_id,
+            (1 - (embedding <=> $1::vector)) AS sem_score
+     FROM stripe_doc_chunks
+     WHERE embedding IS NOT NULL
+     ORDER BY embedding <=> $1::vector
+     LIMIT $2`,
+    [toSql(queryVec), semanticLimit],
+  );
+
+  const byId = new Map();
+  for (const row of kwRows.rows) byId.set(row.id, { ...row });
+  for (const row of semRes.rows) {
+    if (!byId.has(row.id)) byId.set(row.id, { ...row });
+    else Object.assign(byId.get(row.id), row);
+  }
+
+  const rrfScores = reciprocalRankFusion([kwRows.rows, semRes.rows]);
+  const mergedIds = [...rrfScores.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, finalLimit)
+    .map(([id]) => id);
+
+  const results = mergedIds.map((id) => {
+    const row = byId.get(id);
+    return {
+      id,
+      sourceUrl: row.source_url,
+      title: row.title,
+      content: row.content,
+      chunkIndex: row.chunk_index,
+      sourceDocId: row.source_doc_id,
+      rrfScore: rrfScores.get(id),
+      kwRank: row.kw_rank ?? null,
+      semScore: row.sem_score ?? null,
+    };
+  });
+
+  return {
+    results,
+    debug: {
+      keywordHits: kwRows.rows.length,
+      semanticHits: semRes.rows.length,
+    },
+  };
+}

--- a/PBL4/StripeBot/backend/src/services/hybridRagService.js
+++ b/PBL4/StripeBot/backend/src/services/hybridRagService.js
@@ -1,18 +1,24 @@
 import { toSql } from "pgvector";
 import pool from "../config/db.js";
 import { embedText } from "./embeddingService.js";
-
+/** RRF_K (Reciprocal Rank Fusion): the number of results to return */
 const RRF_K = 60;
 
 /**
  * Reciprocal Rank Fusion over two ranked lists.
  * @param {{ id: number }[][]} lists
+ * This function merges multiple ranked search results into a single scoring system using Reciprocal Rank Fusion.
+ * lists: array of ranked results
+ * k: the number of results to return
+ * return: map of id to score
+ * search: Text → embedding (384 numbers) → similarity search → list of results
  */
 function reciprocalRankFusion(lists, k = RRF_K) {
   const scores = new Map();
   for (const list of lists) {
     list.forEach((row, rank) => {
       const id = row.id;
+      /** 1 / (k + rank + 1): rank 1 → high score, rank 10 → low score */
       scores.set(id, (scores.get(id) || 0) + 1 / (k + rank + 1));
     });
   }
@@ -20,7 +26,7 @@ function reciprocalRankFusion(lists, k = RRF_K) {
 }
 
 /**
- * Hybrid search: keyword (FTS) + semantic (cosine via pgvector), fused with RRF.
+ * Hybrid search: keyword (FTS-full text search) + semantic (cosine via pgvector), fused with RRF.
  * @param {string} query
  * @param {{ keywordLimit?: number, semanticLimit?: number, finalLimit?: number }} [opts]
  */
@@ -28,10 +34,15 @@ export async function hybridSearch(query, opts = {}) {
   const keywordLimit = opts.keywordLimit ?? 15;
   const semanticLimit = opts.semanticLimit ?? 15;
   const finalLimit = opts.finalLimit ?? 8;
-
   const q = String(query || "").trim();
   if (!q) return { results: [], debug: { error: "empty query" } };
 
+  /**
+   * kwRows: results from the keyword search
+   * queryVec: the embedding of the query
+   * embedText: function to embed the query
+   * Promise.all: to run the keyword search and the embedding search in parallel
+   */
   const [kwRows, queryVec] = await Promise.all([
     pool.query(
       `SELECT id, source_url, title, content, chunk_index, source_doc_id,
@@ -45,6 +56,16 @@ export async function hybridSearch(query, opts = {}) {
     embedText(q),
   ]);
 
+  /**
+   * semRes: results from the semantic search
+   * queryVec: the embedding of the query
+   * $1::vector: your question’s embedding (queryVec) formatted for pgvector via toSql(queryVec)
+   * embedding <=> $1 — cosine distance between each row’s embedding and the query vector (smaller distance = more similar)
+   * ORDER BY embedding <=> $1::vector: sort the results by the cosine distance
+   * (1 - (embedding <=> $1::vector)) AS sem_score: turns distance into a rough similarity-style score (higher = closer; exact scale depends on pgvector’s cosine distance definition).
+   * LIMIT $2: limit the number of results to the semanticLimit
+   * [toSql(queryVec), semanticLimit]: parameters for the query
+   */
   const semRes = await pool.query(
     `SELECT id, source_url, title, content, chunk_index, source_doc_id,
             (1 - (embedding <=> $1::vector)) AS sem_score
@@ -55,19 +76,26 @@ export async function hybridSearch(query, opts = {}) {
     [toSql(queryVec), semanticLimit],
   );
 
+  /**
+   * merges two result sets and removes duplicates using id
+   * - Keyword search results
+   * - Semantic (vector) search results
+   * Output = one combined dataset
+   */
   const byId = new Map();
   for (const row of kwRows.rows) byId.set(row.id, { ...row });
   for (const row of semRes.rows) {
     if (!byId.has(row.id)) byId.set(row.id, { ...row });
     else Object.assign(byId.get(row.id), row);
   }
-
+  /** It takes keyword + semantic search results, ranks them using RRF, sorts them, and returns the top document IDs.*/
   const rrfScores = reciprocalRankFusion([kwRows.rows, semRes.rows]);
   const mergedIds = [...rrfScores.entries()]
     .sort((a, b) => b[1] - a[1])
     .slice(0, finalLimit)
     .map(([id]) => id);
 
+  /** It takes the top document IDs, maps them to their corresponding rows, and returns the full structured search results. */
   const results = mergedIds.map((id) => {
     const row = byId.get(id);
     return {

--- a/PBL4/StripeBot/backend/src/services/userService.js
+++ b/PBL4/StripeBot/backend/src/services/userService.js
@@ -1,5 +1,6 @@
 import pool from "../config/db.js";
 
+/** Get all users from the database */
 export const getUsers = async () => {
   const result = await pool.query("SELECT * FROM users");
   return result.rows;

--- a/PBL4/StripeBot/backend/src/services/userService.js
+++ b/PBL4/StripeBot/backend/src/services/userService.js
@@ -1,0 +1,6 @@
+import pool from "../config/db.js";
+
+export const getUsers = async () => {
+  const result = await pool.query("SELECT * FROM users");
+  return result.rows;
+};

--- a/PBL4/StripeBot/backend/src/sql/setup.sql
+++ b/PBL4/StripeBot/backend/src/sql/setup.sql
@@ -1,0 +1,16 @@
+-- Legacy single-table shape. For hybrid RAG (chunks + FTS + vectors), use setup_hybrid.sql instead.
+
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE TABLE stripe_docs (
+  id          SERIAL PRIMARY KEY,
+  source_url  TEXT,
+  title       TEXT,
+  content     TEXT,
+  metadata    JSONB,
+  embedding   vector(384)
+);
+
+CREATE INDEX ON stripe_docs 
+  USING hnsw (embedding vector_cosine_ops)
+  WITH (m = 16, ef_construction = 64);

--- a/PBL4/StripeBot/backend/src/sql/setup_hybrid.sql
+++ b/PBL4/StripeBot/backend/src/sql/setup_hybrid.sql
@@ -1,0 +1,29 @@
+-- Hybrid RAG: dense vectors (semantic) + PostgreSQL full-text (keyword).
+-- Run once in Supabase SQL editor (or psql) against your project database.
+
+CREATE EXTENSION IF NOT EXISTS vector;
+
+-- Chunk-level storage (one row per text chunk; replaces single-row-per-doc for RAG quality)
+CREATE TABLE IF NOT EXISTS stripe_doc_chunks (
+  id BIGSERIAL PRIMARY KEY,
+  source_doc_id TEXT NOT NULL,
+  chunk_index INT NOT NULL,
+  source_url TEXT,
+  title TEXT,
+  content TEXT NOT NULL,
+  content_tsv tsvector GENERATED ALWAYS AS (
+    to_tsvector('english', coalesce(title, '') || ' ' || coalesce(content, ''))
+  ) STORED,
+  embedding vector(384),
+  metadata JSONB DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  UNIQUE (source_doc_id, chunk_index)
+);
+
+CREATE INDEX IF NOT EXISTS stripe_doc_chunks_content_tsv_idx
+  ON stripe_doc_chunks USING GIN (content_tsv);
+
+CREATE INDEX IF NOT EXISTS stripe_doc_chunks_embedding_hnsw_idx
+  ON stripe_doc_chunks
+  USING hnsw (embedding vector_cosine_ops)
+  WITH (m = 16, ef_construction = 64);

--- a/PBL4/StripeBot/backend/src/sql/setup_hybrid.sql
+++ b/PBL4/StripeBot/backend/src/sql/setup_hybrid.sql
@@ -19,11 +19,22 @@ CREATE TABLE IF NOT EXISTS stripe_doc_chunks (
   created_at TIMESTAMPTZ DEFAULT now(),
   UNIQUE (source_doc_id, chunk_index)
 );
-
+-- Create index for full-text search (keyword search)
+-- GIN-Generalized Inverted Index: a data structure that allows for fast full-text search
+-- content_tsv: converts text into searchable tokens e.g."I love JavaScript"→ ['love', 'javascript']
 CREATE INDEX IF NOT EXISTS stripe_doc_chunks_content_tsv_idx
   ON stripe_doc_chunks USING GIN (content_tsv);
 
+-- Create index for vector search
+-- HNSW-Hierarchical Navigable Small World Graph: a data structure that allows for fast vector search
+-- Instead of comparing query vector with ALL vectors, HNSW builds a graph of similar vectors
+-- embedding: the vector to search for
+-- vector_cosine_ops: the cosine distance operation-similarity is calculated using cosine distance
+-- m: number of connections per node, more = better accuracy, less = faster search
+-- m = 16: 16 connections per node
+-- ef_construction: controls build quality of index, higher = better accuracy but slower indexing, lower = faster build but less accurate
 CREATE INDEX IF NOT EXISTS stripe_doc_chunks_embedding_hnsw_idx
-  ON stripe_doc_chunks
+  ON stripe_doc_chunk
   USING hnsw (embedding vector_cosine_ops)
   WITH (m = 16, ef_construction = 64);
+


### PR DESCRIPTION
## Summary

Adds a Stripe documentation RAG backend: scrape to JSON, chunk (pluggable), embed with Xenova all-MiniLM-L6-v2 (384-d), upsert into Supabase/Postgres stripe_doc_chunks with FTS + HNSW, and hybrid retrieval (keyword + vector + RRF) behind POST /api/rag/search.

## Changes Made

- Scripts: scrape, testChunk, ingestVectors; npm data:refresh.
- Services: embeddingService, hybridRagService; Express app with /health and /api/rag/search.
- SQL: setup_hybrid.sql for stripe_doc_chunks, GIN on tsvector, HNSW on embeddings.
- Docs: README.md, PROJECT.md.

## How to test
<!-- Describe how to manually test the changes -->

- Run src/sql/setup_hybrid.sql on the target Supabase DB.
- npm run scrape → npm run ingest (or npm run data:refresh).
- npm run dev → GET /health returns 200 with DB time.
- POST /api/rag/search with {"query":"webhook verification","finalLimit":5} returns ranked chunks.

## Checklist

- [ ] Code is properly formatted and linted
- [ ] Feature works as expected
- [ ] Linked issues: Closes #856 #857 #858 #859

## Additional Notes

<!-- Any other relevant information -->
