### PR TITLE
feat: preserve markdown fenced code blocks when chunking scraped pages

### DIFF
--- a/PBL4/StripeBot/backend/src/utils/chunker.js
+++ b/PBL4/StripeBot/backend/src/utils/chunker.js
@@ -48,6 +48,34 @@ function tailByTokens(text, overlapTokens) {
   // Slice the array of IDs to get only the last 'overlapTokens' and decode them into text
   return tokenizer.decode(ids.slice(ids.length - overlapTokens));
 }
+
+/**
+ * Force-split a string into <= maxChunkTokens pieces using a sliding window.
+ * @param {boolean} useOverlap - If false, windows abut (for code; avoids duplicating partial fences).
+ */
+function forceSplitByTokens(
+  text,
+  maxChunkTokens,
+  overlapTokens,
+  tokenizer,
+  createChunkObject,
+  chunks,
+  useOverlap,
+) {
+  const ids = tokenizer.encode(text);
+  const stride = useOverlap
+    ? Math.max(1, maxChunkTokens - overlapTokens)
+    : maxChunkTokens;
+  for (let start = 0; start < ids.length; start += stride) {
+    const end = Math.min(start + maxChunkTokens, ids.length);
+    const piece = tokenizer.decode(ids.slice(start, end));
+    chunks.push(createChunkObject(piece));
+    if (end >= ids.length) break;
+  }
+  const lastPiece = chunks[chunks.length - 1].content;
+  return useOverlap ? tailByTokens(lastPiece, overlapTokens) : "";
+}
+
 /**
  * Chunks a single scraped page object.
  * @param {Object} pageObject - One item from the scraped JSON array

--- a/PBL4/StripeBot/backend/src/utils/chunker.js
+++ b/PBL4/StripeBot/backend/src/utils/chunker.js
@@ -1,6 +1,36 @@
 const { countTokens, getTokenizer } = require("../utils/tokenCounter");
 
 /**
+ * Split markdown into ordered text vs fenced-code segments.
+ * Code values include the full fence (e.g. "```js\n...\n```").
+ * Incomplete fences (no closing line) stay in "text" segments.
+ *
+ * @param {string} content
+ * @returns {{ type: "text" | "code", value: string }[]}
+ */
+function segmentMarkdownByFences(content) {
+  const segments = [];
+  if (content == null || content === "") return segments;
+  const fenceRe =
+    /^```[^\n\r]*\r?\n([\s\S]*?)^```[ \t]*(?:\r?\n|$)/gm;
+  let lastIndex = 0;
+  let match;
+  while ((match = fenceRe.exec(content)) !== null) {
+    const start = match.index;
+    const fullFence = match[0];
+    if (start > lastIndex) {
+      segments.push({ type: "text", value: content.slice(lastIndex, start) });
+    }
+    segments.push({ type: "code", value: fullFence });
+    lastIndex = start + fullFence.length;
+  }
+  if (lastIndex < content.length) {
+    segments.push({ type: "text", value: content.slice(lastIndex) });
+  }
+  return segments;
+}
+
+/**
  * Grabs a specific number of tokens from the very end of a string.
  * This is used to create a "bridge" between two chunks
  * so the AI doesn't lose the meaning of a sentence cut in half.
@@ -66,7 +96,7 @@ function chunkPageObject(pageObject, options = {}) {
     },
   });
 
-  const parts = content.split(/\n\n+/);
+  const parts = content.split(/\n\n+/); //splits string into an array using blank lines(paragraphs)
   let current = "";
 
   for (const part of parts) {
@@ -82,7 +112,7 @@ function chunkPageObject(pageObject, options = {}) {
     }
 
     if (countTokens(part) > maxChunkTokens) {
-      const ids = tokenizer.encode(part);
+      const ids = tokenizer.encode(part); //Turns text into an array of token IDs
       const stride = Math.max(1, maxChunkTokens - overlapTokens);
 
       for (let start = 0; start < ids.length; start += stride) {
@@ -97,7 +127,9 @@ function chunkPageObject(pageObject, options = {}) {
       current = tailByTokens(lastPiece, overlapTokens);
     } else {
       const overlapText = current ? tailByTokens(current, overlapTokens) : "";
-      current = overlapText ? `${overlapText}\n\n${part}` : part;
+      const combined = overlapText ? `${overlapText}\n\n${part}` : part;
+      // If overlap pushes us over, skip the overlap to respect the limit
+      current = countTokens(combined) <= maxChunkTokens ? combined : part;
     }
   }
 
@@ -106,6 +138,7 @@ function chunkPageObject(pageObject, options = {}) {
   }
 
   return chunks;
+  console.log(chunks);
 }
 
 /**
@@ -120,4 +153,4 @@ function chunkScrapedJSON(scrapedPages, options = {}) {
   return scrapedPages.flatMap((page) => chunkPageObject(page, options));
 }
 
-module.exports = { chunkScrapedJSON, chunkPageObject };
+module.exports = { chunkScrapedJSON, chunkPageObject, segmentMarkdownByFences };

--- a/PBL4/StripeBot/backend/src/utils/chunker.js
+++ b/PBL4/StripeBot/backend/src/utils/chunker.js
@@ -11,8 +11,7 @@ const { countTokens, getTokenizer } = require("../utils/tokenCounter");
 function segmentMarkdownByFences(content) {
   const segments = [];
   if (content == null || content === "") return segments;
-  const fenceRe =
-    /^```[^\n\r]*\r?\n([\s\S]*?)^```[ \t]*(?:\r?\n|$)/gm;
+  const fenceRe = /^```[^\n\r]*\r?\n([\s\S]*?)^```[ \t]*(?:\r?\n|$)/gm;
   let lastIndex = 0;
   let match;
   while ((match = fenceRe.exec(content)) !== null) {
@@ -77,6 +76,87 @@ function forceSplitByTokens(
 }
 
 /**
+ * Paragraph-based chunking for a plain text fragment (one or more "text" segments).
+ * Mutates `state`: { current }, `chunks`, via createChunkObject.
+ */
+function processTextSegmentValue(
+  textValue,
+  state,
+  maxChunkTokens,
+  overlapTokens,
+  tokenizer,
+  createChunkObject,
+  chunks,
+) {
+  const parts = textValue.split(/\n\n+/).filter((p) => p.length > 0);
+  for (const part of parts) {
+    const candidate = state.current ? `${state.current}\n\n${part}` : part;
+    if (countTokens(candidate) <= maxChunkTokens) {
+      state.current = candidate;
+      continue;
+    }
+    if (state.current) {
+      chunks.push(createChunkObject(state.current));
+    }
+    if (countTokens(part) > maxChunkTokens) {
+      state.current = forceSplitByTokens(
+        part,
+        maxChunkTokens,
+        overlapTokens,
+        tokenizer,
+        createChunkObject,
+        chunks,
+        true,
+      );
+    } else {
+      const overlapText = state.current
+        ? tailByTokens(state.current, overlapTokens)
+        : "";
+      const combined = overlapText ? `${overlapText}\n\n${part}` : part;
+      state.current = countTokens(combined) <= maxChunkTokens ? combined : part;
+    }
+  }
+}
+
+/**
+ * Append a fenced code block: try current chunk, else flush and new chunk, else force-split without overlap.
+ */
+function processCodeSegmentValue(
+  codeValue,
+  state,
+  maxChunkTokens,
+  tokenizer,
+  createChunkObject,
+  chunks,
+) {
+  const candidate = state.current
+    ? `${state.current}\n\n${codeValue}`
+    : codeValue;
+  if (countTokens(candidate) <= maxChunkTokens) {
+    state.current = candidate;
+    return;
+  }
+  if (state.current) {
+    chunks.push(createChunkObject(state.current));
+    state.current = "";
+  }
+  if (countTokens(codeValue) <= maxChunkTokens) {
+    chunks.push(createChunkObject(codeValue));
+    state.current = "";
+    return;
+  }
+  state.current = forceSplitByTokens(
+    codeValue,
+    maxChunkTokens,
+    0,
+    tokenizer,
+    createChunkObject,
+    chunks,
+    false,
+  );
+}
+
+/**
  * Chunks a single scraped page object.
  * @param {Object} pageObject - One item from the scraped JSON array
  * @param {object} options - { maxChunkTokens, overlapTokens }
@@ -124,49 +204,34 @@ function chunkPageObject(pageObject, options = {}) {
     },
   });
 
-  const parts = content.split(/\n\n+/); //splits string into an array using blank lines(paragraphs)
-  let current = "";
-
-  for (const part of parts) {
-    const candidate = current ? `${current}\n\n${part}` : part;
-
-    if (countTokens(candidate) <= maxChunkTokens) {
-      current = candidate;
-      continue;
-    }
-
-    if (current) {
-      chunks.push(createChunkObject(current));
-    }
-
-    if (countTokens(part) > maxChunkTokens) {
-      const ids = tokenizer.encode(part); //Turns text into an array of token IDs
-      const stride = Math.max(1, maxChunkTokens - overlapTokens);
-
-      for (let start = 0; start < ids.length; start += stride) {
-        const end = Math.min(start + maxChunkTokens, ids.length);
-        const piece = tokenizer.decode(ids.slice(start, end));
-        chunks.push(createChunkObject(piece));
-        if (end >= ids.length) break;
-      }
-
-      // Fix: carry overlap after force-split (was missing before)
-      const lastPiece = chunks[chunks.length - 1].content;
-      current = tailByTokens(lastPiece, overlapTokens);
+  const segments = segmentMarkdownByFences(content);
+  const state = { current: "" };
+  for (const seg of segments) {
+    if (seg.type === "text") {
+      processTextSegmentValue(
+        seg.value,
+        state,
+        maxChunkTokens,
+        overlapTokens,
+        tokenizer,
+        createChunkObject,
+        chunks,
+      );
     } else {
-      const overlapText = current ? tailByTokens(current, overlapTokens) : "";
-      const combined = overlapText ? `${overlapText}\n\n${part}` : part;
-      // If overlap pushes us over, skip the overlap to respect the limit
-      current = countTokens(combined) <= maxChunkTokens ? combined : part;
+      processCodeSegmentValue(
+        seg.value,
+        state,
+        maxChunkTokens,
+        tokenizer,
+        createChunkObject,
+        chunks,
+      );
     }
   }
-
-  if (current) {
-    chunks.push(createChunkObject(current));
+  if (state.current) {
+    chunks.push(createChunkObject(state.current));
   }
-
   return chunks;
-  console.log(chunks);
 }
 
 /**

--- a/PBL4/StripeBot/backend/src/utils/markdownSegments.js
+++ b/PBL4/StripeBot/backend/src/utils/markdownSegments.js
@@ -1,0 +1,102 @@
+/**
+ * Ordered segments for markdown-aware chunking (see temp/code-intergrity-splitting.md).
+ * @typedef {{ type: 'text', value: string } | { type: 'code', value: string }} MarkdownSegment
+ */
+
+/**
+ * True if index `i` is the start of a line (start of string or immediately after newline).
+ * @param {string} s
+ * @param {number} i
+ */
+function isLineStart(s, i) {
+    return i === 0 || s[i - 1] === "\n";
+  }
+  
+  /**
+   * Finds the next line that is only optional indent + closing ``` (CommonMark-style fence line).
+   * @param {string} s
+   * @param {number} from - first character after the newline that ends the opening fence line
+   * @returns {{ lineStart: number, afterLine: number } | null}
+   */
+  function findClosingFenceLine(s, from) {
+    let scan = from;
+    while (scan < s.length) {
+      const nl = s.indexOf("\n", scan);
+      const lineStart = scan;
+      const lineEnd = nl === -1 ? s.length : nl;
+      const line = s.slice(lineStart, lineEnd);
+      if (/^\s*```\s*$/.test(line)) {
+        const afterLine = nl === -1 ? s.length : nl + 1;
+        return { lineStart, afterLine };
+      }
+      if (nl === -1) break;
+      scan = nl + 1;
+    }
+    return null;
+  }
+  
+  /**
+   * Full content → ordered text and fenced-code segments.
+   * Code segment `value` is the full fence from opening ``` through end of closing line.
+   * Unclosed fence: from that ``` to EOF is one text segment.
+   * ``` not at line start is kept as text.
+   *
+   * @param {string} content
+   * @returns {MarkdownSegment[]}
+   */
+  function segmentMarkdownToTextAndCode(content) {
+    if (content == null || content === "") return [];
+  
+    /** @type {MarkdownSegment[]} */
+    const segments = [];
+    let pos = 0;
+  
+    const appendText = (start, end) => {
+      if (end <= start) return;
+      const value = content.slice(start, end);
+      const prev = segments[segments.length - 1];
+      if (prev && prev.type === "text") prev.value += value;
+      else segments.push({ type: "text", value });
+    };
+  
+    while (pos < content.length) {
+      const fenceIdx = content.indexOf("```", pos);
+      if (fenceIdx === -1) {
+        appendText(pos, content.length);
+        break;
+      }
+  
+      if (!isLineStart(content, fenceIdx)) {
+        appendText(pos, fenceIdx + 3);
+        pos = fenceIdx + 3;
+        continue;
+      }
+  
+      appendText(pos, fenceIdx);
+  
+      const openLineEnd = content.indexOf("\n", fenceIdx);
+      if (openLineEnd === -1) {
+        appendText(fenceIdx, content.length);
+        break;
+      }
+  
+      const bodyStart = openLineEnd + 1;
+      const close = findClosingFenceLine(content, bodyStart);
+      if (!close) {
+        appendText(fenceIdx, content.length);
+        break;
+      }
+  
+      const codeValue = content.slice(fenceIdx, close.afterLine);
+      segments.push({ type: "code", value: codeValue });
+      pos = close.afterLine;
+    }
+  
+    return segments;
+  }
+  
+  module.exports = {
+    segmentMarkdownToTextAndCode,
+    isLineStart,
+    findClosingFenceLine,
+  };


### PR DESCRIPTION
## Summary

Chunking no longer treats page content as one flat stream of paragraphs only. It first splits markdown into ordered text and fenced code segments, then chunks text with the existing paragraph + overlap behavior and treats code as a single unit 


 ** Linked issues:** Closes #862




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced content processing for markdown documents containing code blocks
  * Improved text segmentation that intelligently distinguishes between text and code content
  * Optimized content chunking with better token management for mixed content
  * More reliable handling of documentation with embedded code examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->