### PR TITLE
feat: add POST /api/chat entry point with centralized error handling

### DIFF
--- a/PBL4/StripeBot/backend/package.json
+++ b/PBL4/StripeBot/backend/package.json
@@ -2,9 +2,11 @@
   "name": "backend",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "src/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "dev": "node --watch src/index.js",
+    "start": "node src/index.js"
   },
   "keywords": [],
   "author": "",
@@ -12,8 +14,14 @@
   "dependencies": {
     "20": "^3.1.9",
     "@langchain/core": "^1.1.38",
+    "cors": "^2.8.6",
+    "dotenv": "^17.4.1",
+    "express": "^5.2.1",
     "js-tiktoken": "^1.0.21",
     "nvm": "^0.0.4",
     "use": "^3.1.1"
+  },
+  "devDependencies": {
+    "nodemon": "^3.1.14"
   }
 }

--- a/PBL4/StripeBot/backend/requests/my_requests.rest
+++ b/PBL4/StripeBot/backend/requests/my_requests.rest
@@ -1,0 +1,25 @@
+@baseUrl = http://localhost:3000
+@contentType = application/json
+
+### 1) Valid message 
+POST {{baseUrl}}/api/chat
+Content-Type: {{contentType}}
+
+{
+  "message": "How do I get my Stripe invoice?"
+}
+
+### 2) Empty message 
+POST {{baseUrl}}/api/chat
+Content-Type: {{contentType}}
+
+{
+  "message": ""
+}
+
+### 3) Missing message 
+POST {{baseUrl}}/api/chat
+Content-Type: {{contentType}}
+
+{
+}

--- a/PBL4/StripeBot/backend/src/app.js
+++ b/PBL4/StripeBot/backend/src/app.js
@@ -1,10 +1,9 @@
 const express = require("express");
+const chatRoutes = require("./routes/chat.routes");
 const app = express();
 
 app.use(express.json());
 
-app.get("/ping", (_req, res) => {
-  res.status(200).json({ message: "pong" });
-});
+app.use("/api/chat", chatRoutes);
 
 module.exports = app;

--- a/PBL4/StripeBot/backend/src/app.js
+++ b/PBL4/StripeBot/backend/src/app.js
@@ -1,9 +1,13 @@
 const express = require("express");
 const chatRoutes = require("./routes/chat.routes");
+const { errorMiddleware } = require("./middlewares/error.middleware");
+
 const app = express();
 
 app.use(express.json());
 
 app.use("/api/chat", chatRoutes);
+
+app.use(errorMiddleware);
 
 module.exports = app;

--- a/PBL4/StripeBot/backend/src/app.js
+++ b/PBL4/StripeBot/backend/src/app.js
@@ -2,12 +2,16 @@ const express = require("express");
 const chatRoutes = require("./routes/chat.routes");
 const { errorMiddleware } = require("./middlewares/error.middleware");
 
+// Create an Express application instance
 const app = express();
 
+//Parse incoming JSON into JavaScript object  and attaches it to req.body
 app.use(express.json());
 
+// Define routes for the chat API
 app.use("/api/chat", chatRoutes);
 
+// Handle errors centrally using custom middleware
 app.use(errorMiddleware);
 
 module.exports = app;

--- a/PBL4/StripeBot/backend/src/app.js
+++ b/PBL4/StripeBot/backend/src/app.js
@@ -1,0 +1,10 @@
+const express = require("express");
+const app = express();
+
+app.use(express.json());
+
+app.get("/ping", (_req, res) => {
+  res.status(200).json({ message: "pong" });
+});
+
+module.exports = app;

--- a/PBL4/StripeBot/backend/src/constants/apiResponse.js
+++ b/PBL4/StripeBot/backend/src/constants/apiResponse.js
@@ -1,0 +1,18 @@
+// Constants for API error codes
+const ERROR_CODES = {
+  INVALID_PROMPT: "INVALID_PROMPT",
+  INTERNAL_SERVER_ERROR: "INTERNAL_SERVER_ERROR",
+  GENERIC_ERROR: "ERROR",
+};
+
+// Constants for API response messages
+const RESPONSE_MESSAGES = {
+  INVALID_PROMPT: "prompt is required and must be a non-empty string",
+  INTERNAL_SERVER_ERROR: "Something went wrong while processing the request",
+  GENERIC_ERROR: "Request failed",
+};
+
+module.exports = {
+  ERROR_CODES,
+  RESPONSE_MESSAGES,
+};

--- a/PBL4/StripeBot/backend/src/controllers/chat.controller.js
+++ b/PBL4/StripeBot/backend/src/controllers/chat.controller.js
@@ -1,35 +1,29 @@
-const handleChatQuery = async (req, res) => {
-    try {
-      const { message } = req.body || {};
-  
-      if (!message || typeof message !== "string" || !message.trim()) {
-        return res.status(400).json({
-          success: false,
-          error: {
-            code: "INVALID_MESSAGE", //'code' is a machine-readable identifier
-            message: "message is required and must be a non-empty string",
-          },
-        });
-      }
-  
-      return res.status(200).json({
-        success: true,
-        data: {
-          reply: "Placeholder response from /api/chat", //'reply' clearly indicates this is the response from the chat system; chosen to clearly show it is the output, follow chat API naming conventions, and separate from user input
-          receivedMessage: message,
-        },
-      });
-    } catch (error) {
-      console.error("handleChatQuery error:", error);
-  
-      return res.status(500).json({
+const { AppError } = require("../utils/AppError");
+
+const handleChatQuery = async (req, res, next) => {
+  try {
+    const { message } = req.body || {};
+
+    if (!message || typeof message !== "string" || !message.trim()) {
+      return res.status(400).json({
         success: false,
         error: {
-          code: "INTERNAL_SERVER_ERROR",
-          message: "Something went wrong while processing chat request",
+          code: "INVALID_MESSAGE", //'code' is a machine-readable identifier
+          message: "message is required and must be a non-empty string",
         },
       });
     }
-  };
-  
-  module.exports = { handleChatQuery };
+
+    return res.status(200).json({
+      success: true,
+      data: {
+        reply: "Placeholder response from /api/chat", //'reply' clearly indicates this is the response from the chat system; chosen to clearly show it is the output, follow chat API naming conventions, and separate from user input
+        receivedMessage: message,
+      },
+    });
+  } catch (error) {
+    return next(error);
+  }
+};
+
+module.exports = { handleChatQuery };

--- a/PBL4/StripeBot/backend/src/controllers/chat.controller.js
+++ b/PBL4/StripeBot/backend/src/controllers/chat.controller.js
@@ -1,0 +1,35 @@
+const handleChatQuery = async (req, res) => {
+    try {
+      const { message } = req.body || {};
+  
+      if (!message || typeof message !== "string" || !message.trim()) {
+        return res.status(400).json({
+          success: false,
+          error: {
+            code: "INVALID_MESSAGE", //'code' is a machine-readable identifier
+            message: "message is required and must be a non-empty string",
+          },
+        });
+      }
+  
+      return res.status(200).json({
+        success: true,
+        data: {
+          reply: "Placeholder response from /api/chat", //'reply' clearly indicates this is the response from the chat system; chosen to clearly show it is the output, follow chat API naming conventions, and separate from user input
+          receivedMessage: message,
+        },
+      });
+    } catch (error) {
+      console.error("handleChatQuery error:", error);
+  
+      return res.status(500).json({
+        success: false,
+        error: {
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Something went wrong while processing chat request",
+        },
+      });
+    }
+  };
+  
+  module.exports = { handleChatQuery };

--- a/PBL4/StripeBot/backend/src/controllers/chat.controller.js
+++ b/PBL4/StripeBot/backend/src/controllers/chat.controller.js
@@ -1,24 +1,27 @@
 const { AppError } = require("../utils/AppError");
+const { ERROR_CODES, RESPONSE_MESSAGES } = require("../constants/apiResponse");
 
 const handleChatQuery = async (req, res, next) => {
   try {
-    const { message } = req.body || {};
+    const { prompt } = req.body || {};
+    const userPrompt = typeof prompt === "string" ? prompt.trim() : "";
 
-    if (!message || typeof message !== "string" || !message.trim()) {
-      return res.status(400).json({
-        success: false,
-        error: {
-          code: "INVALID_MESSAGE", //'code' is a machine-readable identifier
-          message: "message is required and must be a non-empty string",
-        },
-      });
+    if (!userPrompt) {
+      return next(
+        new AppError(
+          400,
+          ERROR_CODES.INVALID_PROMPT,
+          RESPONSE_MESSAGES.INVALID_PROMPT,
+        ),
+      );
     }
 
     return res.status(200).json({
       success: true,
       data: {
-        reply: "Placeholder response from /api/chat", //'reply' clearly indicates this is the response from the chat system; chosen to clearly show it is the output, follow chat API naming conventions, and separate from user input
-        receivedMessage: message,
+        //'reply' clearly indicates this is the response from the chat system; chosen to clearly show it is the output, follow chat API naming conventions, and separate from user input
+        reply: "Placeholder response from /api/chat",
+        userInput: userPrompt,
       },
     });
   } catch (error) {

--- a/PBL4/StripeBot/backend/src/index.js
+++ b/PBL4/StripeBot/backend/src/index.js
@@ -1,0 +1,8 @@
+require("dotenv").config();
+const app = require("./app");
+
+const PORT = process.env.PORT || 3000;
+
+app.listen(process.env.PORT, () => {
+  console.log(`Server is running on port ${process.env.PORT}`);
+});

--- a/PBL4/StripeBot/backend/src/index.js
+++ b/PBL4/StripeBot/backend/src/index.js
@@ -3,6 +3,6 @@ const app = require("./app");
 
 const PORT = process.env.PORT || 3000;
 
-app.listen(process.env.PORT, () => {
-  console.log(`Server is running on port ${process.env.PORT}`);
+app.listen(PORT, () => {
+  console.log(`Server is running on port ${PORT}`);
 });

--- a/PBL4/StripeBot/backend/src/middlewares/error.middleware.js
+++ b/PBL4/StripeBot/backend/src/middlewares/error.middleware.js
@@ -1,0 +1,41 @@
+/**
+ * Central error formatter. Must be registered after all routes.
+ * Pass errors with: next(err) or throw from sync code.
+ * For async handlers, call next(err) in catch (Express 4 does not auto-catch promises).
+ */
+function errorMiddleware(err, req, res, next) {
+  // If headers already sent, delegate to default Express behavior
+  if (res.headersSent) {
+    return next(err);
+  }
+
+  const statusCode =
+    typeof err.statusCode === "number" &&
+    err.statusCode >= 400 &&
+    err.statusCode < 600
+      ? err.statusCode
+      : 500;
+
+  const code =
+    typeof err.code === "string" && err.code.length > 0
+      ? err.code
+      : statusCode === 500
+        ? "INTERNAL_SERVER_ERROR"
+        : "ERROR";
+
+  const message =
+    statusCode === 500
+      ? "Something went wrong while processing the request"
+      : err.message || "Request failed";
+
+  if (statusCode === 500) {
+    console.error(err);
+  }
+
+  res.status(statusCode).json({
+    success: false,
+    error: { code, message },
+  });
+}
+
+module.exports = { errorMiddleware };

--- a/PBL4/StripeBot/backend/src/middlewares/error.middleware.js
+++ b/PBL4/StripeBot/backend/src/middlewares/error.middleware.js
@@ -1,7 +1,9 @@
+const { ERROR_CODES, RESPONSE_MESSAGES } = require("../constants/apiResponse");
+
 /**
  * Central error formatter. Must be registered after all routes.
  * Pass errors with: next(err) or throw from sync code.
- * For async handlers, call next(err) in catch (Express 4 does not auto-catch promises).
+ * For async handlers, call next(err) in catch.
  */
 function errorMiddleware(err, req, res, next) {
   // If headers already sent, delegate to default Express behavior
@@ -20,13 +22,13 @@ function errorMiddleware(err, req, res, next) {
     typeof err.code === "string" && err.code.length > 0
       ? err.code
       : statusCode === 500
-        ? "INTERNAL_SERVER_ERROR"
-        : "ERROR";
+        ? ERROR_CODES.INTERNAL_SERVER_ERROR
+        : ERROR_CODES.GENERIC_ERROR;
 
   const message =
     statusCode === 500
-      ? "Something went wrong while processing the request"
-      : err.message || "Request failed";
+      ? RESPONSE_MESSAGES.INTERNAL_SERVER_ERROR
+      : err.message || RESPONSE_MESSAGES.GENERIC_ERROR;
 
   if (statusCode === 500) {
     console.error(err);

--- a/PBL4/StripeBot/backend/src/routes/chat.routes.js
+++ b/PBL4/StripeBot/backend/src/routes/chat.routes.js
@@ -1,0 +1,8 @@
+const express = require("express");
+const { handleChatQuery } = require("../controllers/chat.controller");
+
+const router = express.Router();
+
+router.post("/", handleChatQuery);
+
+module.exports = router;

--- a/PBL4/StripeBot/backend/src/utils/AppError.js
+++ b/PBL4/StripeBot/backend/src/utils/AppError.js
@@ -1,3 +1,4 @@
+// Custom error class to standardize API error responses with statusCode and error code
 class AppError extends Error {
   constructor(statusCode, code, message) {
     super(message);

--- a/PBL4/StripeBot/backend/src/utils/AppError.js
+++ b/PBL4/StripeBot/backend/src/utils/AppError.js
@@ -1,0 +1,8 @@
+class AppError extends Error {
+  constructor(statusCode, code, message) {
+    super(message);
+    this.statusCode = statusCode;
+    this.code = code;
+  }
+}
+module.exports = { AppError };


### PR DESCRIPTION
## Summary

Adds a single chat endpoint for the frontend to send user messages. Validates input, returns a placeholder reply, and routes errors through a shared middleware. Includes a REST file for local testing.

## API Contract:

**POST /api/chat**

- Body: { "message": string } (non-empty after trim)
- 200: { success: true, data: { reply, receivedMessage } }
- 400: { success: false, error: { code: "INVALID_MESSAGE", message: "..." } }
- 500: { success: false, error: { code: "INTERNAL_SERVER_ERROR", message: "..." } } Linked issues: Closes #

**Linked issues:** Closes #874 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Launched chat API endpoint (POST /api/chat) for processing user messages with input validation
  * Implemented centralized error handling with consistent error responses

* **Tests**
  * Added REST client test scenarios for the chat API endpoint

<!-- end of auto-generated comment: release notes by coderabbit.ai -->