### PR TITLE
feat: add reusable Gemini AI service for chat responses

### DIFF
--- a/PBL4/StripeBot/backend/package.json
+++ b/PBL4/StripeBot/backend/package.json
@@ -13,6 +13,7 @@
   "license": "ISC",
   "dependencies": {
     "20": "^3.1.9",
+    "@google/generative-ai": "^0.24.1",
     "@langchain/core": "^1.1.38",
     "cors": "^2.8.6",
     "dotenv": "^17.4.1",

--- a/PBL4/StripeBot/backend/src/controllers/chat.controller.js
+++ b/PBL4/StripeBot/backend/src/controllers/chat.controller.js
@@ -1,5 +1,6 @@
 const { AppError } = require("../utils/AppError");
 const { ERROR_CODES, RESPONSE_MESSAGES } = require("../constants/apiResponse");
+const { generateAIResponse } = require("../services/gemini.service");
 
 const handleChatQuery = async (req, res, next) => {
   try {
@@ -16,11 +17,13 @@ const handleChatQuery = async (req, res, next) => {
       );
     }
 
+    const aiResponse = await generateAIResponse(message);
+
     return res.status(200).json({
       success: true,
       data: {
         //'reply' clearly indicates this is the response from the chat system; chosen to clearly show it is the output, follow chat API naming conventions, and separate from user input
-        reply: "Placeholder response from /api/chat",
+        reply: aiResponse,
         userInput: userPrompt,
       },
     });

--- a/PBL4/StripeBot/backend/src/controllers/chat.controller.js
+++ b/PBL4/StripeBot/backend/src/controllers/chat.controller.js
@@ -17,7 +17,7 @@ const handleChatQuery = async (req, res, next) => {
       );
     }
 
-    const aiResponse = await generateAIResponse(message);
+    const aiResponse = await generateAIResponse(userPrompt);
 
     return res.status(200).json({
       success: true,

--- a/PBL4/StripeBot/backend/src/services/gemini.service.js
+++ b/PBL4/StripeBot/backend/src/services/gemini.service.js
@@ -1,0 +1,56 @@
+const { GoogleGenerativeAI } = require("@google/generative-ai");
+const { AppError } = require("../utils/AppError");
+
+const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
+const GEMINI_MODEL = process.env.GEMINI_MODEL || "gemini-2.5-flash";
+
+if (!GEMINI_API_KEY) {
+  throw new Error("Missing GEMINI_API_KEY in environment");
+}
+
+/*
+- Authenticate to google with valid gemini key, checks if key is valid, billing limits,
+- Creates a client instance(genAI) that holds your credentials and is ready to talk to the API.*/
+const genAI = new GoogleGenerativeAI(GEMINI_API_KEY);
+const model = genAI.getGenerativeModel({
+  model: GEMINI_MODEL,
+  systemInstruction:
+    "You are StripeBot, a backend assistant. Be accurate, concise, and practical. If information is missing, ask one clear follow-up question. Do not invent facts. Keep answers under 120 words unless asked for detail.",
+}); //specifies exactly which "version" of the AI to use.
+
+async function generateAIResponse(userPrompt) {
+  if (!userPrompt || typeof userPrompt !== "string" || !userPrompt.trim()) {
+    throw new AppError(
+      400,
+      "INVALID_PROMPT",
+      "Prompt is required and must be a non-empty string",
+    );
+  }
+
+  try {
+    const result = await model.generateContent(userPrompt.trim());
+    const response = result.response.text();
+
+    if (!response) {
+      throw new AppError(
+        502,
+        "EMPTY_AI_RESPONSE",
+        "AI returned an empty response",
+      );
+    }
+
+    return response;
+  } catch (error) {
+    if (error instanceof AppError) throw error;
+
+    console.error("Gemini API Error:", error);
+
+    throw new AppError(
+      500,
+      "AI_GENERATION_FAILED",
+      "Failed to generate AI response",
+    );
+  }
+}
+
+module.exports = { generateAIResponse };

--- a/PBL4/StripeBot/backend/src/services/gemini.service.js
+++ b/PBL4/StripeBot/backend/src/services/gemini.service.js
@@ -3,6 +3,21 @@ const { AppError } = require("../utils/AppError");
 
 const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
 const GEMINI_MODEL = process.env.GEMINI_MODEL || "gemini-2.5-flash";
+const GEMINI_TIMEOUT_MS = Number(process.env.GEMINI_TIMEOUT_MS || 15000);
+
+// Wraps an asynchronous operation with a timeout, so it either returns the result quickly or throws a clear error if it takes too long
+function withTimeout(promise, ms) {
+  let timer;
+  // Promise.race runs multiple promises and returns the result of the one that settles first (resolves or rejects)
+  return Promise.race([
+    promise,
+    new Promise((_, reject) => {
+      timer = setTimeout(() => {
+        reject(new AppError(504, "AI_TIMEOUT", "AI provider timed out"));
+      }, ms);
+    }),
+  ]).finally(() => clearTimeout(timer));
+}
 
 if (!GEMINI_API_KEY) {
   throw new Error("Missing GEMINI_API_KEY in environment");
@@ -28,7 +43,10 @@ async function generateAIResponse(userPrompt) {
   }
 
   try {
-    const result = await model.generateContent(userPrompt.trim());
+    const result = await withTimeout(
+      model.generateContent(userPrompt.trim()),
+      GEMINI_TIMEOUT_MS,
+    );
     const response = result.response.text();
 
     if (!response) {
@@ -43,7 +61,12 @@ async function generateAIResponse(userPrompt) {
   } catch (error) {
     if (error instanceof AppError) throw error;
 
-    console.error("Gemini API Error:", error);
+    console.error("Gemini API Error", {
+      name: error?.name,
+      message: error?.message,
+      code: error?.code,
+      status: error?.status,
+    });
 
     throw new AppError(
       500,


### PR DESCRIPTION

## Summary

- Configured Gemini in backend
- Create reusable service with @google/generative-ai
- Wired chat.controller.js to call that service so /api/chat returns real Gemini responses instead of a placeholder.

 **Linked issues:** Closes #875 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated AI-powered chat responses using Google's Generative AI, enabling the chat feature to generate intelligent replies instead of static placeholders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->