### PR TITLE
feat: add ChatInputBar component to the main application layout

### DIFF
--- a/PBL4/StripeBot/frontend/src/App.jsx
+++ b/PBL4/StripeBot/frontend/src/App.jsx
@@ -1,10 +1,14 @@
-import React from 'react'
-import NavBar from './components/NavBar'
+import React from "react";
+import NavBar from "./components/NavBar";
+import ChatInputBar from "./components/ChatInputBar";
 
 const App = () => {
   return (
-  <NavBar />
-  )
-}
+    <>
+      <NavBar />
+      <ChatInputBar />
+    </>
+  );
+};
 
-export default App
+export default App;

--- a/PBL4/StripeBot/frontend/src/components/ChatInputBar.jsx
+++ b/PBL4/StripeBot/frontend/src/components/ChatInputBar.jsx
@@ -1,0 +1,54 @@
+import React from "react";
+
+const ChatInputBar = () => {
+  return (
+    <div className="relative flex items-center rounded-2xl border border-gray-200 bg-white px-4 py-3 shadow-md w-full max-w-2xl mx-auto mt-[480px]">
+      <button
+        type="button"
+        aria-label="Add attachment"
+        className="mr-2 h-6 w-6 rounded-full border border-gray-200 bg-black text-white flex items-center justify-center leading-none transition-colors hover:bg-gray-200 hover:text-black"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="h-4 w-4"
+        >
+          <path d="M12 5v14" />
+          <path d="M5 12h14" />
+        </svg>
+      </button>
+      <input
+        type="text"
+        placeholder="Type your message..."
+        className="flex-1 bg-transparent pr-12 outline-none"
+        aria-label="Message input"
+      />
+      <button
+        type="button"
+        aria-label="Send message"
+        className="absolute right-2 h-8 w-8 rounded-xl bg-[#516498] text-white flex items-center justify-center"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="h-4 w-4"
+        >
+          <path d="M12 19V5" />
+          <path d="M6 11l6-6 6 6" />
+        </svg>
+      </button>
+    </div>
+  );
+};
+
+export default ChatInputBar;


### PR DESCRIPTION
## Summary

- Added a new `ChatInputBar` component with a clean and centered input UI  
- Included basic styling with input field, action icons, and placeholder text  
- Kept the implementation UI-only to serve as a base for future functionality

## Screenshots

<img width="1454" height="870" alt="Screenshot 2026-04-07 151059" src="https://github.com/user-attachments/assets/3714b985-8ef3-4859-ab12-1bbd09696514" />

## Related Issues
Closes #881 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a chat input bar to the application interface with an attachment button, message input field, and send button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->