### PR TITLE
feat: (1/n)rewrite user prompt into standalone question

### DIFF
--- a/PBL4/StripeBot/backend/requests/my_requests.rest
+++ b/PBL4/StripeBot/backend/requests/my_requests.rest
@@ -1,23 +1,23 @@
 @baseUrl = http://localhost:3000
 @contentType = application/json
 
-### 1) Valid message 
+### 1) Rewrite test 
 POST {{baseUrl}}/api/chat
 Content-Type: {{contentType}}
 
 {
-  "message": "How do I get my Stripe invoice?"
+ "prompt": "Hey, can you tell me what the pricing is?"
 }
 
-### 2) Empty message 
+### 2) Empty prompt 
 POST {{baseUrl}}/api/chat
 Content-Type: {{contentType}}
 
 {
-  "message": ""
+  "prompt": ""
 }
 
-### 3) Missing message 
+### 3) Missing prompt 
 POST {{baseUrl}}/api/chat
 Content-Type: {{contentType}}
 

--- a/PBL4/StripeBot/backend/src/constants/aiPrompts.js
+++ b/PBL4/StripeBot/backend/src/constants/aiPrompts.js
@@ -1,0 +1,16 @@
+// System prompt for rewriting user input into a concise, standalone question
+const REWRITE_SYSTEM_PROMPT = `Transform the user's message into a concise, standalone question optimized for vector search retrieval.
+
+Rules:
+- Remove greetings, filler words, hedges ("I was wondering", "can you help me"), and first-person pronouns.
+- Resolve all conversational references (e.g., "it", "that", "the previous one") using context from the conversation history.
+- Output exactly one grammatically correct, self-contained question.
+- Preserve domain-specific terminology and named entities exactly as written.
+- If the input is already a clean question, return it unchanged.
+- If the intent is ambiguous, lean toward the broader interpretation.
+
+Output: A single plain string. No explanation, no alternatives, no punctuation beyond the question mark.`
+
+module.exports = {
+  REWRITE_SYSTEM_PROMPT,
+};

--- a/PBL4/StripeBot/backend/src/constants/aiPrompts.js
+++ b/PBL4/StripeBot/backend/src/constants/aiPrompts.js
@@ -1,4 +1,5 @@
 // System prompt for rewriting user input into a concise, standalone question
+// TODO(next): Conversation-history-aware rewriting will be added in a follow-up PR; current rewrite uses only the current user prompt.
 const REWRITE_SYSTEM_PROMPT = `Transform the user's message into a concise, standalone question optimized for vector search retrieval.
 
 Rules:

--- a/PBL4/StripeBot/backend/src/constants/aiPrompts.js
+++ b/PBL4/StripeBot/backend/src/constants/aiPrompts.js
@@ -1,5 +1,5 @@
 // System prompt for rewriting user input into a concise, standalone question
-// TODO(next): Conversation-history-aware rewriting will be added in a follow-up PR; current rewrite uses only the current user prompt.
+// TODO(#891): Conversation-history-aware will be added in a follow-up PR;
 const REWRITE_SYSTEM_PROMPT = `Transform the user's message into a concise, standalone question optimized for vector search retrieval.
 
 Rules:
@@ -10,8 +10,12 @@ Rules:
 - If the input is already a clean question, return it unchanged.
 - If the intent is ambiguous, lean toward the broader interpretation.
 
-Output: A single plain string. No explanation, no alternatives, no punctuation beyond the question mark.`
+Output: A single plain string. No explanation, no alternatives, no punctuation beyond the question mark.`;
+
+const REWRITE_FALLBACK_WARN_MESSAGE =
+  "Rewrite failed, falling back to original userPrompt";
 
 module.exports = {
   REWRITE_SYSTEM_PROMPT,
+  REWRITE_FALLBACK_WARN_MESSAGE,
 };

--- a/PBL4/StripeBot/backend/src/constants/apiResponse.js
+++ b/PBL4/StripeBot/backend/src/constants/apiResponse.js
@@ -3,6 +3,9 @@ const ERROR_CODES = {
   INVALID_PROMPT: "INVALID_PROMPT",
   INTERNAL_SERVER_ERROR: "INTERNAL_SERVER_ERROR",
   GENERIC_ERROR: "ERROR",
+  AI_TIMEOUT: "AI_TIMEOUT",
+  EMPTY_AI_RESPONSE: "EMPTY_AI_RESPONSE",
+  AI_GENERATION_FAILED: "AI_GENERATION_FAILED",
 };
 
 // Constants for API response messages
@@ -10,6 +13,9 @@ const RESPONSE_MESSAGES = {
   INVALID_PROMPT: "prompt is required and must be a non-empty string",
   INTERNAL_SERVER_ERROR: "Something went wrong while processing the request",
   GENERIC_ERROR: "Request failed",
+  AI_TIMEOUT: "AI provider timed out",
+  EMPTY_AI_RESPONSE: "AI returned an empty response",
+  AI_GENERATION_FAILED: "Failed to generate AI response",
 };
 
 module.exports = {

--- a/PBL4/StripeBot/backend/src/controllers/chat.controller.js
+++ b/PBL4/StripeBot/backend/src/controllers/chat.controller.js
@@ -20,7 +20,16 @@ const handleChatQuery = async (req, res, next) => {
       );
     }
 
-    const rewrittenQuery = await rewriteQuery(userPrompt);
+    let rewrittenQuery = userPrompt;
+    try {
+      rewrittenQuery = await rewriteQuery(userPrompt);
+    } catch (error) {
+      // Fallback behavior: if rewrite fails, continue with original prompt.
+      console.warn("Rewrite failed, falling back to original userPrompt", {
+        message: error?.message,
+        code: error?.code,
+      });
+    }
 
     /*
     TODO: This PR intentionally validates rewrite flow end-to-end.
@@ -34,7 +43,7 @@ const handleChatQuery = async (req, res, next) => {
         //'reply' clearly indicates this is the response from the chat system; chosen to clearly show it is the output, follow chat API naming conventions, and separate from user input
         reply: aiResponse,
         userInput: userPrompt,
-        rewrittenQuery, //// Temporary: exposed for rewrite verification during this phase.
+        rewrittenQuery, // Temporary: exposed for rewrite verification during this phase.
       },
     });
   } catch (error) {

--- a/PBL4/StripeBot/backend/src/controllers/chat.controller.js
+++ b/PBL4/StripeBot/backend/src/controllers/chat.controller.js
@@ -1,5 +1,6 @@
 const { AppError } = require("../utils/AppError");
 const { ERROR_CODES, RESPONSE_MESSAGES } = require("../constants/apiResponse");
+const { REWRITE_FALLBACK_WARN_MESSAGE } = require("../constants/aiPrompts");
 const {
   generateAIResponse,
   rewriteQuery,
@@ -25,14 +26,14 @@ const handleChatQuery = async (req, res, next) => {
       rewrittenQuery = await rewriteQuery(userPrompt);
     } catch (error) {
       // Fallback behavior: if rewrite fails, continue with original prompt.
-      console.warn("Rewrite failed, falling back to original userPrompt", {
+      console.warn(REWRITE_FALLBACK_WARN_MESSAGE, {
         message: error?.message,
         code: error?.code,
       });
     }
 
     /*
-    TODO: This PR intentionally validates rewrite flow end-to-end.
+    TODO(#887): This PR intentionally validates rewrite flow end-to-end.
     Next PR will use rewrittenQuery for embedding/search and improve this flow.
     */
     const aiResponse = await generateAIResponse(rewrittenQuery);

--- a/PBL4/StripeBot/backend/src/controllers/chat.controller.js
+++ b/PBL4/StripeBot/backend/src/controllers/chat.controller.js
@@ -1,6 +1,9 @@
 const { AppError } = require("../utils/AppError");
 const { ERROR_CODES, RESPONSE_MESSAGES } = require("../constants/apiResponse");
-const { generateAIResponse } = require("../services/gemini.service");
+const {
+  generateAIResponse,
+  rewriteQuery,
+} = require("../services/gemini.service");
 
 const handleChatQuery = async (req, res, next) => {
   try {
@@ -17,7 +20,13 @@ const handleChatQuery = async (req, res, next) => {
       );
     }
 
-    const aiResponse = await generateAIResponse(userPrompt);
+    const rewrittenQuery = await rewriteQuery(userPrompt);
+
+    /*
+    TODO: This PR intentionally validates rewrite flow end-to-end.
+    Next PR will use rewrittenQuery for embedding/search and improve this flow.
+    */
+    const aiResponse = await generateAIResponse(rewrittenQuery);
 
     return res.status(200).json({
       success: true,
@@ -25,6 +34,7 @@ const handleChatQuery = async (req, res, next) => {
         //'reply' clearly indicates this is the response from the chat system; chosen to clearly show it is the output, follow chat API naming conventions, and separate from user input
         reply: aiResponse,
         userInput: userPrompt,
+        rewrittenQuery, //// Temporary: exposed for rewrite verification during this phase.
       },
     });
   } catch (error) {

--- a/PBL4/StripeBot/backend/src/services/gemini.service.js
+++ b/PBL4/StripeBot/backend/src/services/gemini.service.js
@@ -1,5 +1,6 @@
 const { GoogleGenerativeAI } = require("@google/generative-ai");
 const { AppError } = require("../utils/AppError");
+const { REWRITE_SYSTEM_PROMPT } = require("../constants/aiPrompts");
 
 const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
 const GEMINI_MODEL = process.env.GEMINI_MODEL || "gemini-2.5-flash";
@@ -27,11 +28,10 @@ if (!GEMINI_API_KEY) {
 - Authenticate to google with valid gemini key, checks if key is valid, billing limits,
 - Creates a client instance(genAI) that holds your credentials and is ready to talk to the API.*/
 const genAI = new GoogleGenerativeAI(GEMINI_API_KEY);
-const model = genAI.getGenerativeModel({
+const rewriteModel = genAI.getGenerativeModel({
   model: GEMINI_MODEL,
-  systemInstruction:
-    "You are StripeBot, a backend assistant. Be accurate, concise, and practical. If information is missing, ask one clear follow-up question. Do not invent facts. Keep answers under 120 words unless asked for detail.",
-}); //specifies exactly which "version" of the AI to use.
+  systemInstruction: REWRITE_SYSTEM_PROMPT,
+});
 
 async function generateAIResponse(userPrompt) {
   if (!userPrompt || typeof userPrompt !== "string" || !userPrompt.trim()) {

--- a/PBL4/StripeBot/backend/src/services/gemini.service.js
+++ b/PBL4/StripeBot/backend/src/services/gemini.service.js
@@ -45,7 +45,7 @@ const responseModel = genAI.getGenerativeModel({
   model: GEMINI_MODEL,
 });
 
-// TODO(next): This PR tests query rewriting only; response generation flow will be finalized in the upcoming PR.
+// TODO(#889): This PR tests query rewriting only; response generation flow will be finalized in the upcoming PR.
 async function generateAIResponse(userPrompt) {
   if (!userPrompt || typeof userPrompt !== "string" || !userPrompt.trim()) {
     throw new AppError(
@@ -98,21 +98,36 @@ async function rewriteQuery(userPrompt) {
       RESPONSE_MESSAGES.INVALID_PROMPT,
     );
   }
+  try {
+    const result = await withTimeout(
+      rewriteModel.generateContent(userPrompt.trim()),
+      GEMINI_TIMEOUT_MS,
+    );
 
-  const result = await withTimeout(
-    rewriteModel.generateContent(userPrompt),
-    GEMINI_TIMEOUT_MS,
-  );
+    const rewrittenQuery = result.response.text()?.trim().replace(/\s+/g, " ");
+    if (!rewrittenQuery) {
+      throw new AppError(
+        502,
+        ERROR_CODES.EMPTY_AI_RESPONSE,
+        RESPONSE_MESSAGES.EMPTY_AI_RESPONSE,
+      );
+    }
+    return rewrittenQuery;
+  } catch (error) {
+    if (error instanceof AppError) throw error;
 
-  const rewrittenQuery = result.response.text()?.trim().replace(/\s+/g, " ");
-  if (!rewrittenQuery) {
+    console.error("Gemini Rewrite Error", {
+      name: error?.name,
+      message: error?.message,
+      code: error?.code,
+      status: error?.status,
+    });
     throw new AppError(
-      502,
-      ERROR_CODES.EMPTY_AI_RESPONSE,
-      RESPONSE_MESSAGES.EMPTY_AI_RESPONSE,
+      500,
+      ERROR_CODES.AI_GENERATION_FAILED,
+      RESPONSE_MESSAGES.AI_GENERATION_FAILED,
     );
   }
-  return rewrittenQuery;
 }
 
 module.exports = { generateAIResponse, rewriteQuery };

--- a/PBL4/StripeBot/backend/src/services/gemini.service.js
+++ b/PBL4/StripeBot/backend/src/services/gemini.service.js
@@ -76,4 +76,30 @@ async function generateAIResponse(userPrompt) {
   }
 }
 
-module.exports = { generateAIResponse };
+// Rewrites the user prompt into a concise, standalone question
+async function rewriteQuery(userPrompt) {
+  if (!userPrompt || typeof userPrompt !== "string" || !userPrompt.trim()) {
+    throw new AppError(
+      400,
+      "INVALID_PROMPT",
+      "Prompt is required and must be a non-empty string",
+    );
+  }
+
+  const result = await withTimeout(
+    rewriteModel.generateContent(userPrompt),
+    GEMINI_TIMEOUT_MS,
+  );
+
+  const rewrittenQuery = result.response.text()?.trim().replace(/\s+/g, " ");
+  if (!rewrittenQuery) {
+    throw new AppError(
+      502,
+      "EMPTY_AI_RESPONSE",
+      "AI returned an empty response",
+    );
+  }
+  return rewrittenQuery;
+}
+
+module.exports = { generateAIResponse, rewriteQuery };

--- a/PBL4/StripeBot/backend/src/services/gemini.service.js
+++ b/PBL4/StripeBot/backend/src/services/gemini.service.js
@@ -33,6 +33,7 @@ const rewriteModel = genAI.getGenerativeModel({
   systemInstruction: REWRITE_SYSTEM_PROMPT,
 });
 
+// TODO(next): This PR tests query rewriting only; response generation flow will be finalized in the upcoming PR.
 async function generateAIResponse(userPrompt) {
   if (!userPrompt || typeof userPrompt !== "string" || !userPrompt.trim()) {
     throw new AppError(

--- a/PBL4/StripeBot/backend/src/services/gemini.service.js
+++ b/PBL4/StripeBot/backend/src/services/gemini.service.js
@@ -1,6 +1,7 @@
 const { GoogleGenerativeAI } = require("@google/generative-ai");
 const { AppError } = require("../utils/AppError");
 const { REWRITE_SYSTEM_PROMPT } = require("../constants/aiPrompts");
+const { ERROR_CODES, RESPONSE_MESSAGES } = require("../constants/apiResponse");
 
 const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
 const GEMINI_MODEL = process.env.GEMINI_MODEL || "gemini-2.5-flash";
@@ -14,7 +15,13 @@ function withTimeout(promise, ms) {
     promise,
     new Promise((_, reject) => {
       timer = setTimeout(() => {
-        reject(new AppError(504, "AI_TIMEOUT", "AI provider timed out"));
+        reject(
+          new AppError(
+            504,
+            ERROR_CODES.AI_TIMEOUT,
+            RESPONSE_MESSAGES.AI_TIMEOUT,
+          ),
+        );
       }, ms);
     }),
   ]).finally(() => clearTimeout(timer));
@@ -28,9 +35,14 @@ if (!GEMINI_API_KEY) {
 - Authenticate to google with valid gemini key, checks if key is valid, billing limits,
 - Creates a client instance(genAI) that holds your credentials and is ready to talk to the API.*/
 const genAI = new GoogleGenerativeAI(GEMINI_API_KEY);
+
 const rewriteModel = genAI.getGenerativeModel({
   model: GEMINI_MODEL,
   systemInstruction: REWRITE_SYSTEM_PROMPT,
+});
+
+const responseModel = genAI.getGenerativeModel({
+  model: GEMINI_MODEL,
 });
 
 // TODO(next): This PR tests query rewriting only; response generation flow will be finalized in the upcoming PR.
@@ -38,14 +50,14 @@ async function generateAIResponse(userPrompt) {
   if (!userPrompt || typeof userPrompt !== "string" || !userPrompt.trim()) {
     throw new AppError(
       400,
-      "INVALID_PROMPT",
-      "Prompt is required and must be a non-empty string",
+      ERROR_CODES.INVALID_PROMPT,
+      RESPONSE_MESSAGES.INVALID_PROMPT,
     );
   }
 
   try {
     const result = await withTimeout(
-      model.generateContent(userPrompt.trim()),
+      responseModel.generateContent(userPrompt.trim()),
       GEMINI_TIMEOUT_MS,
     );
     const response = result.response.text();
@@ -53,8 +65,8 @@ async function generateAIResponse(userPrompt) {
     if (!response) {
       throw new AppError(
         502,
-        "EMPTY_AI_RESPONSE",
-        "AI returned an empty response",
+        ERROR_CODES.EMPTY_AI_RESPONSE,
+        RESPONSE_MESSAGES.EMPTY_AI_RESPONSE,
       );
     }
 
@@ -71,8 +83,8 @@ async function generateAIResponse(userPrompt) {
 
     throw new AppError(
       500,
-      "AI_GENERATION_FAILED",
-      "Failed to generate AI response",
+      ERROR_CODES.AI_GENERATION_FAILED,
+      RESPONSE_MESSAGES.AI_GENERATION_FAILED,
     );
   }
 }
@@ -82,8 +94,8 @@ async function rewriteQuery(userPrompt) {
   if (!userPrompt || typeof userPrompt !== "string" || !userPrompt.trim()) {
     throw new AppError(
       400,
-      "INVALID_PROMPT",
-      "Prompt is required and must be a non-empty string",
+      ERROR_CODES.INVALID_PROMPT,
+      RESPONSE_MESSAGES.INVALID_PROMPT,
     );
   }
 
@@ -96,8 +108,8 @@ async function rewriteQuery(userPrompt) {
   if (!rewrittenQuery) {
     throw new AppError(
       502,
-      "EMPTY_AI_RESPONSE",
-      "AI returned an empty response",
+      ERROR_CODES.EMPTY_AI_RESPONSE,
+      RESPONSE_MESSAGES.EMPTY_AI_RESPONSE,
     );
   }
   return rewrittenQuery;


### PR DESCRIPTION
## Summary

This PR adds query rewriting so user messages are converted into a clean, standalone question before retrieval/embedding flow.

## Example
- Input: `Hey, can you tell me what the pricing is?`
- Rewritten: `What is the pricing?`

**Linked issues:** Closes #876 

## Additional Notes

- For now, API returns rewrittenQuery so we can check it is correct.
- Later, after embedding/search is fully connected, we can hide rewrittenQuery from API response.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat API responses now include the rewritten query for improved transparency

* **Bug Fixes**
  * Enhanced error handling with specific messages for AI operation timeouts
  * Added dedicated error codes for response generation failures and empty responses
  * Improved error feedback when AI operations encounter issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->