### PR TITLE
[1/n] feat: stabilize StripeBot scrape-chunk-embed-ingest pipeline

### DIFF
--- a/PBL4/StripeBot/backend/package.json
+++ b/PBL4/StripeBot/backend/package.json
@@ -9,26 +9,26 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "node --watch src/index.js",
     "start": "node src/index.js",
-    "test:embedding": "node src/scripts/testEmbeddingConnection.js"
+    "chunk": "node src/utils/chunker.js",
+    "ingest": "node src/scripts/ingestVector.js",
+    "data:refresh": "npm run scrape && npm run ingest"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "20": "^3.1.9",
     "@google/generative-ai": "^0.24.1",
     "@langchain/core": "^1.1.38",
+    "@xenova/transformers": "^2.17.2",
     "cheerio": "^1.2.0",
     "@xenova/transformers": "^2.17.2",
     "cors": "^2.8.6",
     "dotenv": "^17.4.1",
     "express": "^5.2.1",
     "js-tiktoken": "^1.0.21",
-    "nvm": "^0.0.4",
     "pg": "^8.20.0",
     "pgvector": "^0.2.1",
-    "undici": "^7.24.7",
-    "use": "^3.1.1"
+    "undici": "^7.24.7"
   },
   "devDependencies": {
     "nodemon": "^3.1.14"

--- a/PBL4/StripeBot/backend/src/scripts/ingestVector.js
+++ b/PBL4/StripeBot/backend/src/scripts/ingestVector.js
@@ -1,0 +1,97 @@
+require("dotenv").config();
+/** fs: File system module for reading and writing files */
+const fs = require("fs/promises");
+/** path: Path module for working with file paths */
+const path = require("path");
+/** toSql: function to convert the embedding to a SQL vector */
+const { toSql } = require("pgvector");
+/** pool: the database connection pool */
+const pool = require("../config/db");
+/** embedText: function to embed the text */
+const { embedText } = require("../services/embeddingService");
+/** chunkScrapedDocuments: function to chunk the scraped documents */
+const { chunkScrapedJSON } = require("../utils/chunker");
+
+/** main: main function to ingest the vectors */
+async function main() {
+  /** jsonPath: the path to the JSON file containing the scraped documents */
+  const jsonPath = path.join(
+    process.cwd(),
+    "data",
+    "stripe_docs",
+    "scraped.json",
+  );
+  const docs = JSON.parse(await fs.readFile(jsonPath, "utf8"));
+  const chunks = chunkScrapedJSON(docs);
+
+  console.log("📥 Ingest:", docs.length, "doc(s) →", chunks.length, "chunk(s)");
+
+  /** client: the database client */
+  const client = await pool.connect();
+  /** try: try to ingest the vectors */
+  try {
+    /** if INGEST_APPEND is not set to 1, truncate the stripe_doc_chunks table */
+    if (process.env.INGEST_APPEND !== "1") {
+      await client.query("TRUNCATE stripe_doc_chunks RESTART IDENTITY");
+      console.log(
+        "🗑️  Truncated stripe_doc_chunks (set INGEST_APPEND=1 to skip)",
+      );
+    }
+    /** n: the number of chunks ingested
+     * for each chunk, embed the text and insert the vector into the database
+     */
+    let n = 0;
+    /** go through each chunk produced from scraped.json */
+    for (const ch of chunks) {
+      /** embed the text of the chunk */
+      const emb = await embedText(ch.content);
+      const m = ch.metadata;
+      /** insert the vector into the database
+       * embedding (via toSql(emb) for pgvector), metadata as JSON.
+       * ON CONFLICT (source_doc_id, chunk_index) DO UPDATE SET: if the chunk already exists, update the existing chunk
+       * why update: to keep the chunk up to date with the latest version of the document
+       */
+      await client.query(
+        `INSERT INTO stripe_doc_chunks
+   (source_doc_id, chunk_index, source_url, title, content, embedding, metadata)
+   VALUES ($1,$2,$3,$4,$5,$6::vector,$7::jsonb)
+   ON CONFLICT (source_doc_id, chunk_index) DO UPDATE SET
+     source_url = EXCLUDED.source_url,
+     title = EXCLUDED.title,
+     content = EXCLUDED.content,
+     embedding = EXCLUDED.embedding,
+     metadata = EXCLUDED.metadata`,
+        [
+          m.source_id,
+          m.chunk_index,
+          m.url,
+          m.title,
+          ch.content,
+          toSql(emb),
+          JSON.stringify(m),
+        ],
+      );
+      /** increment the number of chunks ingested */
+      n += 1;
+      /** log the progress every 20 chunks
+       */
+      if (n % 20 === 0) console.log(`... embedded ${n}/${chunks.length}`);
+    }
+    console.log("✅ Ingest complete:", n, "row(s) upserted");
+    /** release the database client */
+  } finally {
+    client.release();
+  }
+  /** end the database connection */
+  await pool.end();
+}
+
+/** if the script is run directly, run the main function */
+if (process.argv[1]?.endsWith("ingestVector.js")) {
+  main().catch((e) => {
+    console.error("❌ Ingest failed:", e.message);
+    process.exit(1);
+  });
+}
+
+module.exports = { main };

--- a/PBL4/StripeBot/backend/src/scripts/scraper.js
+++ b/PBL4/StripeBot/backend/src/scripts/scraper.js
@@ -208,7 +208,9 @@ async function scrapeDoc(url, category) {
      * trim leading/trailing spaces and line breaks
      */
     const cleanContent = content
-      .replace(/\s+/g, " ")
+      .replace(/\r\n/g, "\n")
+      .replace(/[ \t]+/g, " ")
+      .replace(/\n{3,}/g, "\n\n")
       .replace(/sk_test_[A-Za-z0-9]+/g, "sk_test_[REDACTED]")
       .replace(/sk_live_[A-Za-z0-9]+/g, "sk_live_[REDACTED]")
       .replace(/whsec_[A-Za-z0-9]+/g, "whsec_[REDACTED]")

--- a/PBL4/StripeBot/backend/src/services/embeddingService.js
+++ b/PBL4/StripeBot/backend/src/services/embeddingService.js
@@ -1,11 +1,21 @@
 // undici provides fetch + related Web APIs for Node
 const { fetch, Headers, Request, Response } = require("undici");
 //Wraps an AI task into one simple call: tokenizes input, runs it through the model, and formats the output into usable results
-const { pipeline } = require("@xenova/transformers"); 
+const { pipeline } = require("@xenova/transformers");
 
 /*
 Polyfill for environments where fetch APIs are missing as @xenova/transformers (used by pipeline(...)) internally expects Web APIs like fetch, Headers, Request, and Response to exist globally.
 This ensures the pipeline function can be used in Node.js environments that don't have these APIs natively.*/
+/** undici: HTTP client for Node.js
+ * use for implement the standard fetch API in Node.js
+ */
+/** xenova/transformers: pipeline for feature extraction
+ * @xenova/transformers: JS library to run ML model locally on CPU
+ * Transformers: refers to a type of AI model architecture
+ * pipeline: helper that loads and runs transformer models easily in JavaScript for feature extraction
+ */
+
+// @xenova/transformers expects Web APIs (Node < 18)
 if (typeof globalThis.fetch === "undefined") globalThis.fetch = fetch;
 if (typeof globalThis.Headers === "undefined") globalThis.Headers = Headers;
 if (typeof globalThis.Request === "undefined") globalThis.Request = Request;
@@ -17,6 +27,11 @@ const TASK = "feature-extraction"; //number-extraction
 const MAX_INPUT_CHARS = 8000;
 const POOLING = "mean";
 const NORMALIZE = true;
+/**
+ * "Xenova/all-MiniLM-L6-v2": embedding model, converts text → 384-dimensional vector (numbers)
+ * 384 dimension: every sentence is converted into a list of 384 numbers
+ * why: it's a small model that is fast and accurate for feature extraction
+ */
 
 /** @type {import('@xenova/transformers').FeatureExtractionPipeline | null} */
 
@@ -74,6 +89,10 @@ async function embedText(text) {
 
 /* Iterates through an array of text, generating embeddings one by one.
 Returns an array of all the vectors generated.*/
+/** @param {string[]} texts
+ * takes multiple texts and returns multiple embedding vectors
+ * vectors: array of embedding vectors
+ */
 async function embedTexts(texts) {
   const vectors = [];
   for (const t of texts) {


### PR DESCRIPTION
## Summary

- Standardize the backend data pipeline flow from scraping to vector ingestion.
- Align chunking and ingestion wiring with current utility modules.
- Improve reliability and operational clarity for running data refresh commands.


## Changes Made

- Updated scraper normalization/redaction behavior to support chunking quality.
- Wired ingest flow to consume chunker output shape consistently.
- Ensured embedding service integration remains compatible with current backend module format.
- Cleaned command flow for running scrape/ingest operations from package.json.
- Added/updated pipeline-related script behavior for predictable execution.

## Why

- Previous flow had inconsistencies between script paths, chunk output shape, and ingest expectations.
- These mismatches risked failed commands, partial ingestion, or malformed DB inserts.
- The new setup makes the pipeline easier to operate, debug, and extend.

## Impact
- Positive: clearer end-to-end pipeline, improved data quality for retrieval, fewer runtime surprises.
- Risk: ingest runtime may still be slow for larger datasets due to mostly sequential embedding/upsert.
- Scale note: as data volume grows (3x+), batching/concurrency and retry controls should be added to avoid throughput bottlenecks.

## Testing Plan

<!-- Describe how to manually test the changes -->

- ✅ Run npm run scrape and verify data/stripe_docs/scraped.json updates.
- ✅ Run ingest command and verify rows are inserted/upserted in stripe_doc_chunks.
- ✅ Confirm chunk metadata maps correctly (source_id, chunk_index, url, title).
- ✅ Start API and check GET /health responds with DB status.


## Screenshots

<!-- Include relevant screenshots for UI changes -->

## Checklist

- [ ] Code is properly formatted and linted
- [ ] No console.log or debugging code left in
- [ ] Feature works as expected
- [ ] Linked issues: Closes #869 #895 #870 #896 #871 

## Additional Notes

<!-- Any other relevant information -->
