### PR TITLE
Stripebot 890 chore centralize query validation

### DIFF
--- a/PBL4/StripeBot/backend/src/constants/apiResponse.js
+++ b/PBL4/StripeBot/backend/src/constants/apiResponse.js
@@ -1,6 +1,7 @@
 // Constants for API error codes
 const ERROR_CODES = {
   INVALID_PROMPT: "INVALID_PROMPT",
+  QUERY_TOO_LONG: "QUERY_TOO_LONG",
   INTERNAL_SERVER_ERROR: "INTERNAL_SERVER_ERROR",
   GENERIC_ERROR: "ERROR",
   AI_TIMEOUT: "AI_TIMEOUT",
@@ -11,6 +12,7 @@ const ERROR_CODES = {
 // Constants for API response messages
 const RESPONSE_MESSAGES = {
   INVALID_PROMPT: "prompt is required and must be a non-empty string",
+  QUERY_TOO_LONG: "prompt exceeds maximum allowed length",
   INTERNAL_SERVER_ERROR: "Something went wrong while processing the request",
   GENERIC_ERROR: "Request failed",
   AI_TIMEOUT: "AI provider timed out",

--- a/PBL4/StripeBot/backend/src/controllers/chat.controller.js
+++ b/PBL4/StripeBot/backend/src/controllers/chat.controller.js
@@ -1,4 +1,4 @@
-const { AppError } = require("../utils/AppError");
+const { validateQuery } = require("../utils/validateQuery");
 const { ERROR_CODES, RESPONSE_MESSAGES } = require("../constants/apiResponse");
 const { REWRITE_FALLBACK_WARN_MESSAGE } = require("../constants/aiPrompts");
 const {
@@ -9,17 +9,7 @@ const {
 const handleChatQuery = async (req, res, next) => {
   try {
     const { prompt } = req.body || {};
-    const userPrompt = typeof prompt === "string" ? prompt.trim() : "";
-
-    if (!userPrompt) {
-      return next(
-        new AppError(
-          400,
-          ERROR_CODES.INVALID_PROMPT,
-          RESPONSE_MESSAGES.INVALID_PROMPT,
-        ),
-      );
-    }
+    const userPrompt = validateQuery(prompt);
 
     let rewrittenQuery = userPrompt;
     try {

--- a/PBL4/StripeBot/backend/src/services/gemini.service.js
+++ b/PBL4/StripeBot/backend/src/services/gemini.service.js
@@ -1,5 +1,6 @@
 const { GoogleGenerativeAI } = require("@google/generative-ai");
 const { AppError } = require("../utils/AppError");
+const { validateQuery } = require("../utils/validateQuery");
 const { REWRITE_SYSTEM_PROMPT } = require("../constants/aiPrompts");
 const { ERROR_CODES, RESPONSE_MESSAGES } = require("../constants/apiResponse");
 
@@ -47,17 +48,11 @@ const responseModel = genAI.getGenerativeModel({
 
 // TODO(#889): This PR tests query rewriting only; response generation flow will be finalized in the upcoming PR.
 async function generateAIResponse(userPrompt) {
-  if (!userPrompt || typeof userPrompt !== "string" || !userPrompt.trim()) {
-    throw new AppError(
-      400,
-      ERROR_CODES.INVALID_PROMPT,
-      RESPONSE_MESSAGES.INVALID_PROMPT,
-    );
-  }
+  const cleanPrompt = validateQuery(userPrompt);
 
   try {
     const result = await withTimeout(
-      responseModel.generateContent(userPrompt.trim()),
+      responseModel.generateContent(cleanPrompt),
       GEMINI_TIMEOUT_MS,
     );
     const response = result.response.text();
@@ -91,16 +86,11 @@ async function generateAIResponse(userPrompt) {
 
 // Rewrites the user prompt into a concise, standalone question
 async function rewriteQuery(userPrompt) {
-  if (!userPrompt || typeof userPrompt !== "string" || !userPrompt.trim()) {
-    throw new AppError(
-      400,
-      ERROR_CODES.INVALID_PROMPT,
-      RESPONSE_MESSAGES.INVALID_PROMPT,
-    );
-  }
+const cleanPrompt = validateQuery(userPrompt);
+
   try {
     const result = await withTimeout(
-      rewriteModel.generateContent(userPrompt.trim()),
+      rewriteModel.generateContent(cleanPrompt),
       GEMINI_TIMEOUT_MS,
     );
 

--- a/PBL4/StripeBot/backend/src/utils/validateQuery.js
+++ b/PBL4/StripeBot/backend/src/utils/validateQuery.js
@@ -8,18 +8,14 @@ const DEFAULT_MAX_QUERY_LENGTH = 1000;
  * - Ensures string input
  * - Trims whitespace
  * - Rejects empty query
- * - Enforces max length (throws by default, optionally truncates)
- * 
+ * - Enforces max length (throws by default)
+ *
  * Parameters:
  * - input: The user query string to validate
  * - options: An object with optional settings:
  *   - maxLength: The maximum length of the query (default: DEFAULT_MAX_QUERY_LENGTH)
- *  - truncate: Whether to truncate the query if it exceeds maxLength (default: false)
  */
-function validateQuery(
-  input,
-  { maxLength = DEFAULT_MAX_QUERY_LENGTH, truncate = false } = {},
-) {
+function validateQuery(input, { maxLength = DEFAULT_MAX_QUERY_LENGTH } = {}) {
   if (typeof input !== "string") {
     throw new AppError(
       400,
@@ -39,14 +35,9 @@ function validateQuery(
   }
 
   if (query.length > maxLength) {
-    if (truncate) {
-      return query.slice(0, maxLength);
-    }
-
-    // Keeps current error contract without requiring new error constants yet
     throw new AppError(
       400,
-      ERROR_CODES.INVALID_PROMPT,
+      ERROR_CODES.QUERY_TOO_LONG,
       RESPONSE_MESSAGES.QUERY_TOO_LONG,
     );
   }

--- a/PBL4/StripeBot/backend/src/utils/validateQuery.js
+++ b/PBL4/StripeBot/backend/src/utils/validateQuery.js
@@ -15,7 +15,8 @@ const DEFAULT_MAX_QUERY_LENGTH = 1000;
  * - options: An object with optional settings:
  *   - maxLength: The maximum length of the query (default: DEFAULT_MAX_QUERY_LENGTH)
  */
-function validateQuery(input, { maxLength = DEFAULT_MAX_QUERY_LENGTH } = {}) {
+function validateQuery(input, options = {}) {
+  const maxLength = options.maxLength ?? DEFAULT_MAX_QUERY_LENGTH;
   if (typeof input !== "string") {
     throw new AppError(
       400,

--- a/PBL4/StripeBot/backend/src/utils/validateQuery.js
+++ b/PBL4/StripeBot/backend/src/utils/validateQuery.js
@@ -1,0 +1,57 @@
+const { AppError } = require("./AppError");
+const { ERROR_CODES, RESPONSE_MESSAGES } = require("../constants/apiResponse");
+
+const DEFAULT_MAX_QUERY_LENGTH = 1000;
+
+/**
+ * Validates and normalizes user query input.
+ * - Ensures string input
+ * - Trims whitespace
+ * - Rejects empty query
+ * - Enforces max length (throws by default, optionally truncates)
+ * 
+ * Parameters:
+ * - input: The user query string to validate
+ * - options: An object with optional settings:
+ *   - maxLength: The maximum length of the query (default: DEFAULT_MAX_QUERY_LENGTH)
+ *  - truncate: Whether to truncate the query if it exceeds maxLength (default: false)
+ */
+function validateQuery(
+  input,
+  { maxLength = DEFAULT_MAX_QUERY_LENGTH, truncate = false } = {},
+) {
+  if (typeof input !== "string") {
+    throw new AppError(
+      400,
+      ERROR_CODES.INVALID_PROMPT,
+      RESPONSE_MESSAGES.INVALID_PROMPT,
+    );
+  }
+
+  const query = input.trim();
+
+  if (!query) {
+    throw new AppError(
+      400,
+      ERROR_CODES.INVALID_PROMPT,
+      RESPONSE_MESSAGES.INVALID_PROMPT,
+    );
+  }
+
+  if (query.length > maxLength) {
+    if (truncate) {
+      return query.slice(0, maxLength);
+    }
+
+    // Keeps current error contract without requiring new error constants yet
+    throw new AppError(
+      400,
+      ERROR_CODES.INVALID_PROMPT,
+      RESPONSE_MESSAGES.QUERY_TOO_LONG,
+    );
+  }
+
+  return query;
+}
+
+module.exports = { validateQuery, DEFAULT_MAX_QUERY_LENGTH };


### PR DESCRIPTION
## Summary

- Added a centralized query validation utility in `src/utils/validateQuery.js` to normalize prompt handling in one place.
- Updated chat flow to use shared validation in both `src/controllers/chat.controller.js` and `src/services/gemini.service.js` to avoid duplicate trim/empty checks.
- Extended API constants in `src/constants/apiResponse.js` with `QUERY_TOO_LONG` messaging for oversized prompt handling.

**Linked issues:** Closes #890 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented query length validation with a maximum limit of 1,000 characters per prompt. Users receive standardized error messages when queries exceed the allowed length.

* **Refactor**
  * Consolidated prompt validation logic across core services to ensure consistent error handling and uniform response behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->