### PR TITLE
[2/n] feat: hybrid RAG pipeline, DB setup, and backend docs

### DIFF
--- a/PBL4/StripeBot/backend/PROJECT.md
+++ b/PBL4/StripeBot/backend/PROJECT.md
@@ -1,0 +1,124 @@
+# StripeBot Backend — Project documentation
+
+This document explains **what this service is**, **why it matters**, and how reviewers and new teammates should think about it. Operational steps live in **[README.md](./README.md)**.
+
+---
+
+## What this project is
+
+**StripeBot backend** is a small **retrieval layer** for a Stripe-focused assistant:
+
+1. **Collects** public Stripe documentation text from a **curated list of URLs** (`scraper.js`).
+2. **Chunks** each page with **token-aware** splitting and overlap (`utils/chunker.js` + `tokenCounter.js`), driven from **`ingestVector.js`** (no separate required “chunk-only” script in the default flow).
+3. **Embeds** chunks locally with **`Xenova/all-MiniLM-L6-v2`** (384 dimensions, mean pooling, L2-normalized in code) and stores rows in **Supabase Postgres** with **pgvector** and a **generated `tsvector`** column for full-text search.
+4. **Retrieves** with **hybrid search**: PostgreSQL **FTS** + **cosine-style vector distance** (`<=>`), fused with **reciprocal rank fusion (RRF)** in `hybridRagService.js`.
+
+The HTTP surface includes:
+
+- **`GET /api/rag`** — lightweight DB connectivity check.
+- **`POST /api/rag/search`** — hybrid retrieval for RAG or demos.
+- **`POST /api/chat`** — optional Gemini-backed chat (`gemini.service.js`), separate from retrieval.
+
+An LLM “answer” layer would typically sit **upstream** of or **after** retrieval, using `results[].content` and citations (`sourceUrl`, `title`, etc.) as context.
+
+---
+
+## Why it matters
+
+| Concern              | How this backend helps                                              |
+| -------------------- | ------------------------------------------------------------------- |
+| Grounded answers     | Retrieval returns stored doc chunks, not model-only guessing.       |
+| Exact phrases / IDs  | **FTS** fits error codes, API names, pasted strings.                |
+| Paraphrases          | **Embeddings** help when wording differs from the docs.             |
+| One datastore        | Postgres holds text, vectors, and FTS index together.             |
+| Clear pipeline stages| Scrape → ingest → query maps to separate tasks and ownership.       |
+
+---
+
+## Scope (in / out)
+
+**In scope**
+
+- Seed URL scraping with rate limiting and HTML cleanup + **secret-like redaction** in `scraper.js`.
+- Chunk-level storage and hybrid search API.
+- Optional chat route using Google Gemini when configured.
+
+**Out of scope (unless added later)**
+
+- Full-site crawl or sitemap-driven discovery.
+- Multi-tenant auth / row-level security modeling.
+- JS-rendered-only pages (no Playwright in the default scraper).
+- Production-grade ingest parallelism (current ingest is intentionally simple).
+
+---
+
+## Architectural principles
+
+1. **Separation of concerns** — Scripts (`scraper`, `ingestVector`) vs HTTP (`app` + routes + controllers) vs domain services (`hybridRagService`, `embeddingService`).
+2. **CommonJS** — `"type": "commonjs"`; use `require` / `module.exports` consistently.
+3. **Schema matches embeddings** — `vector(384)` in SQL must match the embedding model; changing model dimension requires migration + **full re-ingest**.
+4. **Hybrid retrieval** — RRF is a simple baseline so neither FTS nor vectors dominates by default.
+5. **Errors** — Controllers prefer `next(err)` so `errorMiddleware` can format responses consistently (health may still attach `statusCode` for 503).
+
+---
+
+## Key dependencies
+
+| Dependency               | Role                                  | Note                                              |
+| ------------------------ | ------------------------------------- | ------------------------------------------------- |
+| Supabase / Postgres      | Chunks, vectors, FTS                  | SSL; secrets in `.env` only.                      |
+| `pg` + `pgvector`        | Typed vectors + `toSql` for queries   | Pool registers vector type on connect.            |
+| `@xenova/transformers`   | Local embeddings                      | First run downloads weights.                      |
+| `cheerio` + `undici`     | Scrape static HTML                    | Not a browser.                                    |
+| `js-tiktoken`            | Token counts for chunking             | Model/encoding configurable via env in tokenCounter.|
+| `express`                | HTTP API                              | Routes under `src/routes`, handlers in `controllers`. |
+| `@google/generative-ai`  | Chat only                             | Requires `GEMINI_API_KEY` when using `/api/chat`. |
+
+---
+
+## Security and compliance
+
+- Never commit `.env` or database URLs in docs/screenshots.
+- Encode special characters in `DATABASE_URL` passwords.
+- Respect Stripe’s terms and rate limits for non-demo use.
+- Redaction in `scraper.js` reduces accidental key-like strings in stored text; it is **not** a guarantee—never log real secrets.
+
+---
+
+## Risks and trade-offs
+
+| Risk              | Note                                                                 |
+| ----------------- | -------------------------------------------------------------------- |
+| Thin URL coverage | Quality improves with more curated URLs or controlled crawling.      |
+| Ingest duration   | Sequential embed + insert; scale may need batching/concurrency.      |
+| Model change      | New embedding model ⇒ new dimension ⇒ migration + re-ingest.         |
+| FTS language      | `english` config may be suboptimal for mixed-language content.       |
+| SQL tooling       | Supabase “explain analyze” mode breaks DDL; use plain Run for setup. |
+
+---
+
+## Maintenance checklist
+
+- [ ] `setup_hybrid.sql` applied to the database pointed to by `.env`.
+- [ ] `npm run scrape` produces non-empty `data/stripe_docs/scraped.json`.
+- [ ] `npm run ingest` completes without vector dimension / cast errors.
+- [ ] `GET /api/rag` returns `{ ok: true, db: true, ... }` when DB is up.
+- [ ] `POST /api/rag/search` returns sensible results on known queries (keyword + semantic legs).
+- [ ] After scraper changes, spot-check chunk boundaries (paragraph newlines preserved in `cleanContent`).
+
+---
+
+## Handoff notes
+
+- **Chunking:** Primary logic is `src/utils/chunker.js` (`chunkScrapedJSON`, `chunkPageObject`). Ingest calls it from `ingestVector.js`; keep the **metadata shape** (`source_id`, `chunk_index`, `url`, …) aligned with SQL columns.
+- **Frontend / RAG client:** Call `POST /api/rag/search` with `{ query }`; use `results[].content` and citation fields in prompts.
+- **Health monitoring:** Use `GET /api/rag` (or add a dedicated `/health` alias in `app.js` if your platform expects that path).
+
+---
+
+## Document map
+
+| File                     | Audience                          |
+| ------------------------ | --------------------------------- |
+| [README.md](./README.md) | Run, integrate, troubleshoot      |
+| **PROJECT.md** (this)    | Leads, reviewers, onboarding    |

--- a/PBL4/StripeBot/backend/README.md
+++ b/PBL4/StripeBot/backend/README.md
@@ -1,0 +1,202 @@
+# StripeBot — Backend
+
+Hybrid RAG backend: scrape Stripe docs → **chunk** (token-aware) → **embed** → **Supabase (Postgres + pgvector)** → **keyword + semantic** search fused with **RRF**.
+
+For product context, scope, and trade-offs, see **[PROJECT.md](./PROJECT.md)**.
+
+---
+
+## Pipeline overview
+
+```mermaid
+flowchart LR
+  subgraph collect
+    A[Stripe doc URLs] --> B[scraper.js]
+    B --> C[scraped.json]
+  end
+  subgraph prepare
+    C --> D[chunker.js]
+    D --> E[Text chunks + metadata]
+  end
+  subgraph embed_store
+    E --> F[embeddingService.js]
+    F --> G[384-d vectors]
+    G --> H[(Supabase Postgres)]
+    H --> I[stripe_doc_chunks]
+    I --> J[content_tsv / FTS]
+    I --> K[embedding / HNSW]
+  end
+  subgraph query
+    Q[User query] --> L[hybridRagService.js]
+    L --> J
+    L --> K
+    L --> M[RRF fusion]
+    M --> N[Ranked chunks]
+  end
+```
+
+### Commands vs flow
+
+```mermaid
+flowchart TB
+  subgraph npm
+    scrape[npm run scrape]
+    ingest[npm run ingest]
+    refresh[npm run data:refresh]
+    dev[npm run dev]
+  end
+  scrape --> JSON[data/stripe_docs/scraped.json]
+  JSON --> ingest
+  scrape --> refresh
+  refresh --> ingest
+  ingest --> DB[(Supabase)]
+  dev --> API[Express src/index.js]
+  API --> routes[routes + controllers]
+  routes --> hybrid[hybridRagService]
+  hybrid --> DB
+```
+
+Chunking runs **inside** `ingestVector.js` via `chunkScrapedJSON` from `src/utils/chunker.js` (no separate mandatory chunk step).
+
+---
+
+## Quick start
+
+1. **Install**
+
+   ```bash
+   cd PBL4/StripeBot/backend
+   npm install
+   ```
+
+2. **Configure** `.env`
+
+   - `DATABASE_URL` _or_ `PGHOST`, `PGPORT`, `PGDATABASE`, `PGUSER`, `PGPASSWORD`
+   - Optional scrape tuning: `RATE_LIMIT_DELAY`, `SCRAPE_FETCH_TIMEOUT_MS`, `SCRAPE_USER_AGENT`
+   - **Chat** (optional): `GEMINI_API_KEY`, `GEMINI_MODEL` (see `gemini.service.js`)
+   - **Ingest**: default run **truncates** `stripe_doc_chunks`. Set `INGEST_APPEND=1` to skip truncate (upsert only).
+
+3. **Database (Supabase)**
+
+   In the Supabase **SQL Editor**, run the full file (normal **Run**, not “Explain analyze” for DDL):
+
+   [`src/sql/setup_hybrid.sql`](./src/sql/setup_hybrid.sql)
+
+   This enables `vector`, creates `stripe_doc_chunks` (384-d embeddings, generated `tsvector`, GIN + HNSW indexes).
+
+4. **Scrape → ingest → API**
+
+   ```bash
+   npm run scrape
+   npm run ingest
+   npm run dev
+   ```
+
+   One-shot data refresh (scrape + ingest, no server):
+
+   ```bash
+   npm run data:refresh
+   ```
+
+   First ingest run downloads the embedding model (can be slow).
+
+---
+
+## NPM scripts
+
+| Script                 | Purpose                                                                 |
+| ---------------------- | ----------------------------------------------------------------------- |
+| `npm run scrape`       | Fetch seed Stripe URLs → `data/stripe_docs/scraped.json`                |
+| `npm run ingest`       | Read JSON → `chunkScrapedJSON` → embed → upsert `stripe_doc_chunks`     |
+| `npm run data:refresh` | `scrape` then `ingest`                                                  |
+| `npm run dev`          | API with `node --watch src/index.js`                                   |
+| `npm start`            | API without watch                                                       |
+| `npm run chunk`        | Loads `chunker.js` as a module only — **not** a standalone chunk preview. Prefer relying on `ingest` or add a small `scripts/chunkPreview.js` if needed. |
+
+`dev` does **not** auto-scrape or auto-ingest on boot.
+
+---
+
+## HTTP API
+
+Entry: `src/index.js` loads `src/app.js`.
+
+| Method | Path                 | Body / notes                                                                 |
+| ------ | -------------------- | ---------------------------------------------------------------------------- |
+| `GET`  | `/api/rag`           | DB health (`SELECT now()`). Same handler as legacy “health” demos.           |
+| `POST` | `/api/rag/search`    | `{ "query": "string", "keywordLimit"?, "semanticLimit"?, "finalLimit"? }`   |
+| `POST` | `/api/chat`          | `{ "prompt": "string" }` → `{ success, data: { reply, userInput } }` (Gemini). |
+
+Example hybrid search:
+
+```bash
+curl -s -X POST http://localhost:3000/api/rag/search \
+  -H "Content-Type: application/json" \
+  -d '{"query":"webhook signature","finalLimit":5}'
+```
+
+Health example:
+
+```bash
+curl -s http://localhost:3000/api/rag
+```
+
+Default port: **3000** (`PORT` env overrides).
+
+---
+
+## Project layout (high signal)
+
+| Path                                 | Role                                                        |
+| ------------------------------------ | ----------------------------------------------------------- |
+| `src/index.js`                       | `dotenv`, `listen(PORT)`                                    |
+| `src/app.js`                         | Express app: JSON middleware, mount routes, error handler |
+| `src/routes/chat.routes.js`          | `POST /` → chat                                            |
+| `src/routes/rag.routes.js`           | `GET /` health, `POST /search` → RAG                        |
+| `src/controllers/rag.controller.js`  | `getHealth`, `handleRagSearch`                            |
+| `src/controllers/chat.controller.js` | Chat handler                                               |
+| `src/scripts/scraper.js`             | Fetch + Cheerio → `scraped.json`                           |
+| `src/scripts/ingestVector.js`        | JSON → chunk → embed → DB                                 |
+| `src/utils/chunker.js`               | Token-based chunking (`chunkScrapedJSON`)                   |
+| `src/utils/tokenCounter.js`          | tiktoken helpers for chunk sizing                         |
+| `src/services/embeddingService.js`   | `Xenova/all-MiniLM-L6-v2` (384-d, mean pool, normalized)   |
+| `src/services/hybridRagService.js`   | FTS + vector + RRF                                        |
+| `src/config/db.js`                   | `pg` pool + `pgvector` type registration                  |
+| `src/sql/setup_hybrid.sql`           | Schema for hybrid RAG                                     |
+
+Legacy: `src/sql/setup.sql` (if present) may target older tables; **hybrid flow uses `setup_hybrid.sql`**.
+
+---
+
+## Ingest behavior
+
+- **Truncate:** Unless `INGEST_APPEND=1`, ingest runs `TRUNCATE stripe_doc_chunks RESTART IDENTITY` before upserts.
+- **Chunking:** Defaults in `chunker.js`: `maxChunkTokens` 800, `overlapTokens` 100 (pass options from ingest if you extend the script).
+- **Upsert key:** `(source_doc_id, chunk_index)` per `setup_hybrid.sql`.
+
+---
+
+## Supabase SQL editor tips
+
+- Do **not** run `CREATE EXTENSION` / `CREATE TABLE` with **Explain analyze** enabled (invalid for DDL).
+- Query **`stripe_doc_chunks`**, not `stripe_docs`, unless you created that table separately.
+
+---
+
+## Troubleshooting
+
+| Symptom                                       | Likely cause                                                                 |
+| --------------------------------------------- | ---------------------------------------------------------------------------- |
+| `relation "stripe_doc_chunks" does not exist` | Run `setup_hybrid.sql` on the **same** DB as `.env`.                         |
+| `EXPLAIN ANALYZE CREATE EXTENSION` error      | Turn off analyze/explain mode; run plain `CREATE EXTENSION ...`.             |
+| `Headers is not defined` (transformers)       | `embeddingService.js` polyfills fetch/Headers via `undici`; use Node 18+.    |
+| Empty keyword hits                            | Stopwords or phrasing; try different query text.                             |
+| RAG 500 on keyword leg                        | Ensure `hybridRagService` keyword SQL uses alias `kw_rank` matching `ORDER BY`. |
+| Scrape CLI args                               | Use `npm run scrape -- --sources=api --limit=1` (`--` before script args).   |
+| Missing `health.controller`                   | Health lives in `rag.controller.js`; routes import from there.              |
+
+---
+
+## Related doc
+
+- **[PROJECT.md](./PROJECT.md)** — architecture notes, scope, risks, maintenance checklist.

--- a/PBL4/StripeBot/backend/src/app.js
+++ b/PBL4/StripeBot/backend/src/app.js
@@ -1,7 +1,7 @@
 const express = require("express");
 const chatRoutes = require("./routes/chat.routes");
 const { errorMiddleware } = require("./middlewares/error.middleware");
-const pool = require("./config/db");
+const ragRoutes = require("./routes/rag.routes");
 
 // Create an Express application instance
 const app = express();
@@ -11,15 +11,7 @@ app.use(express.json());
 
 // Define routes for the chat API
 app.use("/api/chat", chatRoutes);
-
-app.get("/health", async (req, res) => {
-  try {
-    const r = await pool.query("SELECT NOW() AS now");
-    res.json({ ok: true, db: true, time: r.rows[0].now });
-  } catch (err) {
-    res.status(503).json({ ok: false, db: false, error: err.message });
-  }
-});
+app.use("/api/rag", ragRoutes);
 
 // Handle errors centrally using custom middleware
 app.use(errorMiddleware);

--- a/PBL4/StripeBot/backend/src/controllers/rag.controller.js
+++ b/PBL4/StripeBot/backend/src/controllers/rag.controller.js
@@ -1,0 +1,40 @@
+const pool = require("../config/db");
+const { hybridSearch } = require("../services/hybridRagService");
+const { AppError } = require("../utils/AppError");
+const { ERROR_CODES, RESPONSE_MESSAGES } = require("../constants/apiResponse");
+
+const getHealth = async (req, res, next) => {
+  try {
+    const r = await pool.query("SELECT NOW() AS now");
+    res.json({ ok: true, db: true, time: r.rows[0].now });
+  } catch (err) {
+    err.statusCode = 503;
+    next(err);
+  }
+};
+
+const handleRagSearch = async (req, res, next) => {
+  try {
+    const { query, keywordLimit, semanticLimit, finalLimit } = req.body || {};
+    const q = typeof query === "string" ? query.trim() : "";
+    if (!q) {
+      return next(
+        new AppError(
+          400,
+          ERROR_CODES.INVALID_PROMPT,
+          RESPONSE_MESSAGES.INVALID_PROMPT,
+        ),
+      );
+    }
+    const out = await hybridSearch(q, {
+      keywordLimit,
+      semanticLimit,
+      finalLimit,
+    });
+    res.json(out);
+  } catch (err) {
+    next(err);
+  }
+};
+
+module.exports = { getHealth, handleRagSearch };

--- a/PBL4/StripeBot/backend/src/routes/rag.routes.js
+++ b/PBL4/StripeBot/backend/src/routes/rag.routes.js
@@ -1,0 +1,9 @@
+const express = require("express");
+const { getHealth, handleRagSearch } = require("../controllers/rag.controller");
+
+const ragRouter = express.Router();
+
+ragRouter.get("/", getHealth);
+ragRouter.post("/search", handleRagSearch);
+
+module.exports = ragRouter;

--- a/PBL4/StripeBot/backend/src/scripts/scraper.js
+++ b/PBL4/StripeBot/backend/src/scripts/scraper.js
@@ -200,7 +200,6 @@ async function scrapeDoc(url, category) {
       };
       title = categoryTitles[category] ?? "Documentation";
     }
-
     /**
      * content: raw text from the page
      * replace multiple whitespace with single space

--- a/PBL4/StripeBot/backend/src/services/hybridRagService.js
+++ b/PBL4/StripeBot/backend/src/services/hybridRagService.js
@@ -1,0 +1,123 @@
+const { toSql } = require("pgvector");
+const pool = require("../config/db");
+const { embedText } = require("./embeddingService");
+/** RRF_K (Reciprocal Rank Fusion): the number of results to return */
+const RRF_K = 60;
+
+/**
+ * Reciprocal Rank Fusion over two ranked lists.
+ * @param {{ id: number }[][]} lists
+ * This function merges multiple ranked search results into a single scoring system using Reciprocal Rank Fusion.
+ * lists: array of ranked results
+ * k: the number of results to return
+ * return: map of id to score
+ * search: Text → embedding (384 numbers) → similarity search → list of results
+ */
+function reciprocalRankFusion(lists, k = RRF_K) {
+  const scores = new Map();
+  for (const list of lists) {
+    list.forEach((row, rank) => {
+      const id = row.id;
+      /** 1 / (k + rank + 1): rank 1 → high score, rank 10 → low score */
+      scores.set(id, (scores.get(id) || 0) + 1 / (k + rank + 1));
+    });
+  }
+  return scores;
+}
+
+/**
+ * Hybrid search: keyword (FTS-full text search) + semantic (cosine via pgvector), fused with RRF.
+ * @param {string} query
+ * @param {{ keywordLimit?: number, semanticLimit?: number, finalLimit?: number }} [opts]
+ */
+async function hybridSearch(query, opts = {}) {
+  const keywordLimit = opts.keywordLimit ?? 15;
+  const semanticLimit = opts.semanticLimit ?? 15;
+  const finalLimit = opts.finalLimit ?? 8;
+  const q = String(query || "").trim();
+  if (!q) return { results: [], debug: { error: "empty query" } };
+
+  /**
+   * kwRows: results from the keyword search
+   * queryVec: the embedding of the query
+   * embedText: function to embed the query
+   * Promise.all: to run the keyword search and the embedding search in parallel
+   */
+  const [kwRows, queryVec] = await Promise.all([
+    pool.query(
+      `SELECT id, source_url, title, content, chunk_index, source_doc_id,
+              ts_rank_cd(content_tsv, plainto_tsquery('english', $1)) AS kw_rank
+               FROM stripe_doc_chunks
+       WHERE content_tsv @@ plainto_tsquery('english', $1)
+       ORDER BY kw_rank DESC
+       LIMIT $2`,
+      [q, keywordLimit],
+    ),
+    embedText(q),
+  ]);
+
+  /**
+   * semRes: results from the semantic search
+   * queryVec: the embedding of the query
+   * $1::vector: your question’s embedding (queryVec) formatted for pgvector via toSql(queryVec)
+   * embedding <=> $1 — cosine distance between each row’s embedding and the query vector (smaller distance = more similar)
+   * ORDER BY embedding <=> $1::vector: sort the results by the cosine distance
+   * (1 - (embedding <=> $1::vector)) AS sem_score: turns distance into a rough similarity-style score (higher = closer; exact scale depends on pgvector’s cosine distance definition).
+   * LIMIT $2: limit the number of results to the semanticLimit
+   * [toSql(queryVec), semanticLimit]: parameters for the query
+   */
+  const semRes = await pool.query(
+    `SELECT id, source_url, title, content, chunk_index, source_doc_id,
+    (1 - (embedding <=> $1::vector)) AS sem_score
+FROM stripe_doc_chunks
+WHERE embedding IS NOT NULL
+ORDER BY embedding <=> $1::vector
+LIMIT $2`,
+    [toSql(queryVec), semanticLimit],
+  );
+
+  /**
+   * merges two result sets and removes duplicates using id
+   * - Keyword search results
+   * - Semantic (vector) search results
+   * Output = one combined dataset
+   */
+  const byId = new Map();
+  for (const row of kwRows.rows) byId.set(row.id, { ...row });
+  for (const row of semRes.rows) {
+    if (!byId.has(row.id)) byId.set(row.id, { ...row });
+    else Object.assign(byId.get(row.id), row);
+  }
+  /** It takes keyword + semantic search results, ranks them using RRF, sorts them, and returns the top document IDs.*/
+  const rrfScores = reciprocalRankFusion([kwRows.rows, semRes.rows]);
+  const mergedIds = [...rrfScores.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, finalLimit)
+    .map(([id]) => id);
+
+  /** It takes the top document IDs, maps them to their corresponding rows, and returns the full structured search results. */
+  const results = mergedIds.map((id) => {
+    const row = byId.get(id);
+    return {
+      id,
+      sourceUrl: row.source_url,
+      title: row.title,
+      content: row.content,
+      chunkIndex: row.chunk_index,
+      sourceDocId: row.source_doc_id,
+      rrfScore: rrfScores.get(id),
+      kwRank: row.kw_rank ?? null,
+      semScore: row.sem_score ?? null,
+    };
+  });
+
+  return {
+    results,
+    debug: {
+      keywordHits: kwRows.rows.length,
+      semanticHits: semRes.rows.length,
+    },
+  };
+}
+
+module.exports = { hybridSearch };

--- a/PBL4/StripeBot/backend/src/sql/setup_hybrid.sql
+++ b/PBL4/StripeBot/backend/src/sql/setup_hybrid.sql
@@ -1,0 +1,39 @@
+-- Hybrid RAG: dense vectors (semantic) + PostgreSQL full-text (keyword).
+-- Run once in Supabase SQL editor (or psql) against your project database.
+
+CREATE EXTENSION IF NOT EXISTS vector;
+
+-- Chunk-level storage (one row per text chunk; replaces single-row-per-doc for RAG quality)
+CREATE TABLE IF NOT EXISTS stripe_doc_chunks (
+  id BIGSERIAL PRIMARY KEY,
+  source_doc_id TEXT NOT NULL,
+  chunk_index INT NOT NULL,
+  source_url TEXT,
+  title TEXT,
+  content TEXT NOT NULL,
+  content_tsv tsvector GENERATED ALWAYS AS (
+    to_tsvector('english', coalesce(title, '') || ' ' || coalesce(content, ''))
+  ) STORED,
+  embedding vector(384),
+  metadata JSONB DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  UNIQUE (source_doc_id, chunk_index)
+);
+-- Create index for full-text search (keyword search)
+-- GIN-Generalized Inverted Index: a data structure that allows for fast full-text search
+-- content_tsv: converts text into searchable tokens e.g."I love JavaScript"→ ['love', 'javascript']
+CREATE INDEX IF NOT EXISTS stripe_doc_chunks_content_tsv_idx
+  ON stripe_doc_chunks USING GIN (content_tsv);
+
+-- Create index for vector search
+-- HNSW-Hierarchical Navigable Small World Graph: a data structure that allows for fast vector search
+-- Instead of comparing query vector with ALL vectors, HNSW builds a graph of similar vectors
+-- embedding: the vector to search for
+-- vector_cosine_ops: the cosine distance operation-similarity is calculated using cosine distance
+-- m: number of connections per node, more = better accuracy, less = faster search
+-- m = 16: 16 connections per node
+-- ef_construction: controls build quality of index, higher = better accuracy but slower indexing, lower = faster build but less accurate
+CREATE INDEX IF NOT EXISTS stripe_doc_chunks_embedding_hnsw_idx
+  ON stripe_doc_chunks
+  USING hnsw (embedding vector_cosine_ops)
+  WITH (m = 16, ef_construction = 64);


### PR DESCRIPTION
## Summary

Adds hybrid retrieval (FTS + pgvector + RRF), Supabase-oriented schema SQL, fixes the RAG router import, and updates README/PROJECT so the pipeline and API match the codebase.

## Changes Made

- RAG: hybridRagService.js — keyword + semantic search with RRF fusion.
- DB: setup_hybrid.sql — stripe_doc_chunks, tsvector, GIN + HNSW for 384-d embeddings.
- API: rag.routes.js — import health + search from rag.controller.js (removes broken health.controller reference).
- Docs: README.md / PROJECT.md — scripts, paths, env vars, /api/rag + /api/chat, Supabase SQL editor notes.
- Other (if included in branch): gemini.service.js updates; ingest/chunking/embedding wiring as per your commits.

## How to test

<!-- Describe how to manually test the changes -->

- Run src/sql/setup_hybrid.sql on the target DB (plain SQL, not EXPLAIN on DDL).
- npm run scrape → npm run ingest (check INGEST_APPEND vs truncate).
- npm run dev → GET /api/rag → POST /api/rag/search with { "query": "…" }.
- If chat is in scope: POST /api/chat with { "prompt": "…" } and valid Gemini env.

## Checklist

- [ ] Code follows existing patterns (CommonJS, controllers/routes).
- [ ] No dead imports / broken requires.
- [ ] Docs match actual routes and scripts.
- [ ] Tested against real Supabase/Postgres (or noted if N/A).
- [ ] Linked issues: Closes #868 #900 #901 #902 #903

## Additional Notes

<!-- Any other relevant information -->

## Risks / notes:

- Schema dimension (384) must match embedding model; changing model requires migration + re-ingest.
- First ingest downloads embedding weights (slow).
