### PR TITLE
[3/n ]feat: add stdio MCP server with Stripe status and Google web search tools

### DIFF
--- a/PBL4/StripeBot/backend/PROJECT.md
+++ b/PBL4/StripeBot/backend/PROJECT.md
@@ -1,0 +1,124 @@
+# StripeBot Backend — Project documentation
+
+This document explains **what this service is**, **why it matters**, and how reviewers and new teammates should think about it. Operational steps live in **[README.md](./README.md)**.
+
+---
+
+## What this project is
+
+**StripeBot backend** is a small **retrieval layer** for a Stripe-focused assistant:
+
+1. **Collects** public Stripe documentation text from a **curated list of URLs** (`scraper.js`).
+2. **Chunks** each page with **token-aware** splitting and overlap (`utils/chunker.js` + `tokenCounter.js`), driven from **`ingestVector.js`** (no separate required “chunk-only” script in the default flow).
+3. **Embeds** chunks locally with **`Xenova/all-MiniLM-L6-v2`** (384 dimensions, mean pooling, L2-normalized in code) and stores rows in **Supabase Postgres** with **pgvector** and a **generated `tsvector`** column for full-text search.
+4. **Retrieves** with **hybrid search**: PostgreSQL **FTS** + **cosine-style vector distance** (`<=>`), fused with **reciprocal rank fusion (RRF)** in `hybridRagService.js`.
+
+The HTTP surface includes:
+
+- **`GET /api/rag`** — lightweight DB connectivity check.
+- **`POST /api/rag/search`** — hybrid retrieval for RAG or demos.
+- **`POST /api/chat`** — optional Gemini-backed chat (`gemini.service.js`), separate from retrieval.
+
+An LLM “answer” layer would typically sit **upstream** of or **after** retrieval, using `results[].content` and citations (`sourceUrl`, `title`, etc.) as context.
+
+---
+
+## Why it matters
+
+| Concern              | How this backend helps                                              |
+| -------------------- | ------------------------------------------------------------------- |
+| Grounded answers     | Retrieval returns stored doc chunks, not model-only guessing.       |
+| Exact phrases / IDs  | **FTS** fits error codes, API names, pasted strings.                |
+| Paraphrases          | **Embeddings** help when wording differs from the docs.             |
+| One datastore        | Postgres holds text, vectors, and FTS index together.             |
+| Clear pipeline stages| Scrape → ingest → query maps to separate tasks and ownership.       |
+
+---
+
+## Scope (in / out)
+
+**In scope**
+
+- Seed URL scraping with rate limiting and HTML cleanup + **secret-like redaction** in `scraper.js`.
+- Chunk-level storage and hybrid search API.
+- Optional chat route using Google Gemini when configured.
+
+**Out of scope (unless added later)**
+
+- Full-site crawl or sitemap-driven discovery.
+- Multi-tenant auth / row-level security modeling.
+- JS-rendered-only pages (no Playwright in the default scraper).
+- Production-grade ingest parallelism (current ingest is intentionally simple).
+
+---
+
+## Architectural principles
+
+1. **Separation of concerns** — Scripts (`scraper`, `ingestVector`) vs HTTP (`app` + routes + controllers) vs domain services (`hybridRagService`, `embeddingService`).
+2. **CommonJS** — `"type": "commonjs"`; use `require` / `module.exports` consistently.
+3. **Schema matches embeddings** — `vector(384)` in SQL must match the embedding model; changing model dimension requires migration + **full re-ingest**.
+4. **Hybrid retrieval** — RRF is a simple baseline so neither FTS nor vectors dominates by default.
+5. **Errors** — Controllers prefer `next(err)` so `errorMiddleware` can format responses consistently (health may still attach `statusCode` for 503).
+
+---
+
+## Key dependencies
+
+| Dependency               | Role                                  | Note                                              |
+| ------------------------ | ------------------------------------- | ------------------------------------------------- |
+| Supabase / Postgres      | Chunks, vectors, FTS                  | SSL; secrets in `.env` only.                      |
+| `pg` + `pgvector`        | Typed vectors + `toSql` for queries   | Pool registers vector type on connect.            |
+| `@xenova/transformers`   | Local embeddings                      | First run downloads weights.                      |
+| `cheerio` + `undici`     | Scrape static HTML                    | Not a browser.                                    |
+| `js-tiktoken`            | Token counts for chunking             | Model/encoding configurable via env in tokenCounter.|
+| `express`                | HTTP API                              | Routes under `src/routes`, handlers in `controllers`. |
+| `@google/generative-ai`  | Chat only                             | Requires `GEMINI_API_KEY` when using `/api/chat`. |
+
+---
+
+## Security and compliance
+
+- Never commit `.env` or database URLs in docs/screenshots.
+- Encode special characters in `DATABASE_URL` passwords.
+- Respect Stripe’s terms and rate limits for non-demo use.
+- Redaction in `scraper.js` reduces accidental key-like strings in stored text; it is **not** a guarantee—never log real secrets.
+
+---
+
+## Risks and trade-offs
+
+| Risk              | Note                                                                 |
+| ----------------- | -------------------------------------------------------------------- |
+| Thin URL coverage | Quality improves with more curated URLs or controlled crawling.      |
+| Ingest duration   | Sequential embed + insert; scale may need batching/concurrency.      |
+| Model change      | New embedding model ⇒ new dimension ⇒ migration + re-ingest.         |
+| FTS language      | `english` config may be suboptimal for mixed-language content.       |
+| SQL tooling       | Supabase “explain analyze” mode breaks DDL; use plain Run for setup. |
+
+---
+
+## Maintenance checklist
+
+- [ ] `setup_hybrid.sql` applied to the database pointed to by `.env`.
+- [ ] `npm run scrape` produces non-empty `data/stripe_docs/scraped.json`.
+- [ ] `npm run ingest` completes without vector dimension / cast errors.
+- [ ] `GET /api/rag` returns `{ ok: true, db: true, ... }` when DB is up.
+- [ ] `POST /api/rag/search` returns sensible results on known queries (keyword + semantic legs).
+- [ ] After scraper changes, spot-check chunk boundaries (paragraph newlines preserved in `cleanContent`).
+
+---
+
+## Handoff notes
+
+- **Chunking:** Primary logic is `src/utils/chunker.js` (`chunkScrapedJSON`, `chunkPageObject`). Ingest calls it from `ingestVector.js`; keep the **metadata shape** (`source_id`, `chunk_index`, `url`, …) aligned with SQL columns.
+- **Frontend / RAG client:** Call `POST /api/rag/search` with `{ query }`; use `results[].content` and citation fields in prompts.
+- **Health monitoring:** Use `GET /api/rag` (or add a dedicated `/health` alias in `app.js` if your platform expects that path).
+
+---
+
+## Document map
+
+| File                     | Audience                          |
+| ------------------------ | --------------------------------- |
+| [README.md](./README.md) | Run, integrate, troubleshoot      |
+| **PROJECT.md** (this)    | Leads, reviewers, onboarding    |

--- a/PBL4/StripeBot/backend/README.md
+++ b/PBL4/StripeBot/backend/README.md
@@ -1,0 +1,202 @@
+# StripeBot — Backend
+
+Hybrid RAG backend: scrape Stripe docs → **chunk** (token-aware) → **embed** → **Supabase (Postgres + pgvector)** → **keyword + semantic** search fused with **RRF**.
+
+For product context, scope, and trade-offs, see **[PROJECT.md](./PROJECT.md)**.
+
+---
+
+## Pipeline overview
+
+```mermaid
+flowchart LR
+  subgraph collect
+    A[Stripe doc URLs] --> B[scraper.js]
+    B --> C[scraped.json]
+  end
+  subgraph prepare
+    C --> D[chunker.js]
+    D --> E[Text chunks + metadata]
+  end
+  subgraph embed_store
+    E --> F[embeddingService.js]
+    F --> G[384-d vectors]
+    G --> H[(Supabase Postgres)]
+    H --> I[stripe_doc_chunks]
+    I --> J[content_tsv / FTS]
+    I --> K[embedding / HNSW]
+  end
+  subgraph query
+    Q[User query] --> L[hybridRagService.js]
+    L --> J
+    L --> K
+    L --> M[RRF fusion]
+    M --> N[Ranked chunks]
+  end
+```
+
+### Commands vs flow
+
+```mermaid
+flowchart TB
+  subgraph npm
+    scrape[npm run scrape]
+    ingest[npm run ingest]
+    refresh[npm run data:refresh]
+    dev[npm run dev]
+  end
+  scrape --> JSON[data/stripe_docs/scraped.json]
+  JSON --> ingest
+  scrape --> refresh
+  refresh --> ingest
+  ingest --> DB[(Supabase)]
+  dev --> API[Express src/index.js]
+  API --> routes[routes + controllers]
+  routes --> hybrid[hybridRagService]
+  hybrid --> DB
+```
+
+Chunking runs **inside** `ingestVector.js` via `chunkScrapedJSON` from `src/utils/chunker.js` (no separate mandatory chunk step).
+
+---
+
+## Quick start
+
+1. **Install**
+
+   ```bash
+   cd PBL4/StripeBot/backend
+   npm install
+   ```
+
+2. **Configure** `.env`
+
+   - `DATABASE_URL` _or_ `PGHOST`, `PGPORT`, `PGDATABASE`, `PGUSER`, `PGPASSWORD`
+   - Optional scrape tuning: `RATE_LIMIT_DELAY`, `SCRAPE_FETCH_TIMEOUT_MS`, `SCRAPE_USER_AGENT`
+   - **Chat** (optional): `GEMINI_API_KEY`, `GEMINI_MODEL` (see `gemini.service.js`)
+   - **Ingest**: default run **truncates** `stripe_doc_chunks`. Set `INGEST_APPEND=1` to skip truncate (upsert only).
+
+3. **Database (Supabase)**
+
+   In the Supabase **SQL Editor**, run the full file (normal **Run**, not “Explain analyze” for DDL):
+
+   [`src/sql/setup_hybrid.sql`](./src/sql/setup_hybrid.sql)
+
+   This enables `vector`, creates `stripe_doc_chunks` (384-d embeddings, generated `tsvector`, GIN + HNSW indexes).
+
+4. **Scrape → ingest → API**
+
+   ```bash
+   npm run scrape
+   npm run ingest
+   npm run dev
+   ```
+
+   One-shot data refresh (scrape + ingest, no server):
+
+   ```bash
+   npm run data:refresh
+   ```
+
+   First ingest run downloads the embedding model (can be slow).
+
+---
+
+## NPM scripts
+
+| Script                 | Purpose                                                                 |
+| ---------------------- | ----------------------------------------------------------------------- |
+| `npm run scrape`       | Fetch seed Stripe URLs → `data/stripe_docs/scraped.json`                |
+| `npm run ingest`       | Read JSON → `chunkScrapedJSON` → embed → upsert `stripe_doc_chunks`     |
+| `npm run data:refresh` | `scrape` then `ingest`                                                  |
+| `npm run dev`          | API with `node --watch src/index.js`                                   |
+| `npm start`            | API without watch                                                       |
+| `npm run chunk`        | Loads `chunker.js` as a module only — **not** a standalone chunk preview. Prefer relying on `ingest` or add a small `scripts/chunkPreview.js` if needed. |
+
+`dev` does **not** auto-scrape or auto-ingest on boot.
+
+---
+
+## HTTP API
+
+Entry: `src/index.js` loads `src/app.js`.
+
+| Method | Path                 | Body / notes                                                                 |
+| ------ | -------------------- | ---------------------------------------------------------------------------- |
+| `GET`  | `/api/rag`           | DB health (`SELECT now()`). Same handler as legacy “health” demos.           |
+| `POST` | `/api/rag/search`    | `{ "query": "string", "keywordLimit"?, "semanticLimit"?, "finalLimit"? }`   |
+| `POST` | `/api/chat`          | `{ "prompt": "string" }` → `{ success, data: { reply, userInput } }` (Gemini). |
+
+Example hybrid search:
+
+```bash
+curl -s -X POST http://localhost:3000/api/rag/search \
+  -H "Content-Type: application/json" \
+  -d '{"query":"webhook signature","finalLimit":5}'
+```
+
+Health example:
+
+```bash
+curl -s http://localhost:3000/api/rag
+```
+
+Default port: **3000** (`PORT` env overrides).
+
+---
+
+## Project layout (high signal)
+
+| Path                                 | Role                                                        |
+| ------------------------------------ | ----------------------------------------------------------- |
+| `src/index.js`                       | `dotenv`, `listen(PORT)`                                    |
+| `src/app.js`                         | Express app: JSON middleware, mount routes, error handler |
+| `src/routes/chat.routes.js`          | `POST /` → chat                                            |
+| `src/routes/rag.routes.js`           | `GET /` health, `POST /search` → RAG                        |
+| `src/controllers/rag.controller.js`  | `getHealth`, `handleRagSearch`                            |
+| `src/controllers/chat.controller.js` | Chat handler                                               |
+| `src/scripts/scraper.js`             | Fetch + Cheerio → `scraped.json`                           |
+| `src/scripts/ingestVector.js`        | JSON → chunk → embed → DB                                 |
+| `src/utils/chunker.js`               | Token-based chunking (`chunkScrapedJSON`)                   |
+| `src/utils/tokenCounter.js`          | tiktoken helpers for chunk sizing                         |
+| `src/services/embeddingService.js`   | `Xenova/all-MiniLM-L6-v2` (384-d, mean pool, normalized)   |
+| `src/services/hybridRagService.js`   | FTS + vector + RRF                                        |
+| `src/config/db.js`                   | `pg` pool + `pgvector` type registration                  |
+| `src/sql/setup_hybrid.sql`           | Schema for hybrid RAG                                     |
+
+Legacy: `src/sql/setup.sql` (if present) may target older tables; **hybrid flow uses `setup_hybrid.sql`**.
+
+---
+
+## Ingest behavior
+
+- **Truncate:** Unless `INGEST_APPEND=1`, ingest runs `TRUNCATE stripe_doc_chunks RESTART IDENTITY` before upserts.
+- **Chunking:** Defaults in `chunker.js`: `maxChunkTokens` 800, `overlapTokens` 100 (pass options from ingest if you extend the script).
+- **Upsert key:** `(source_doc_id, chunk_index)` per `setup_hybrid.sql`.
+
+---
+
+## Supabase SQL editor tips
+
+- Do **not** run `CREATE EXTENSION` / `CREATE TABLE` with **Explain analyze** enabled (invalid for DDL).
+- Query **`stripe_doc_chunks`**, not `stripe_docs`, unless you created that table separately.
+
+---
+
+## Troubleshooting
+
+| Symptom                                       | Likely cause                                                                 |
+| --------------------------------------------- | ---------------------------------------------------------------------------- |
+| `relation "stripe_doc_chunks" does not exist` | Run `setup_hybrid.sql` on the **same** DB as `.env`.                         |
+| `EXPLAIN ANALYZE CREATE EXTENSION` error      | Turn off analyze/explain mode; run plain `CREATE EXTENSION ...`.             |
+| `Headers is not defined` (transformers)       | `embeddingService.js` polyfills fetch/Headers via `undici`; use Node 18+.    |
+| Empty keyword hits                            | Stopwords or phrasing; try different query text.                             |
+| RAG 500 on keyword leg                        | Ensure `hybridRagService` keyword SQL uses alias `kw_rank` matching `ORDER BY`. |
+| Scrape CLI args                               | Use `npm run scrape -- --sources=api --limit=1` (`--` before script args).   |
+| Missing `health.controller`                   | Health lives in `rag.controller.js`; routes import from there.              |
+
+---
+
+## Related doc
+
+- **[PROJECT.md](./PROJECT.md)** — architecture notes, scope, risks, maintenance checklist.

--- a/PBL4/StripeBot/backend/package.json
+++ b/PBL4/StripeBot/backend/package.json
@@ -11,7 +11,8 @@
     "start": "node src/index.js",
     "chunk": "node src/utils/chunker.js",
     "ingest": "node src/scripts/ingestVector.js",
-    "data:refresh": "npm run scrape && npm run ingest"
+    "data:refresh": "npm run scrape && npm run ingest",
+    "mcp": "node src/mcp/mcpServer.js"
   },
   "keywords": [],
   "author": "",
@@ -19,6 +20,7 @@
   "dependencies": {
     "@google/generative-ai": "^0.24.1",
     "@langchain/core": "^1.1.38",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@xenova/transformers": "^2.17.2",
     "cheerio": "^1.2.0",
     "cors": "^2.8.6",
@@ -27,7 +29,8 @@
     "js-tiktoken": "^1.0.21",
     "pg": "^8.20.0",
     "pgvector": "^0.2.1",
-    "undici": "^7.24.7"
+    "undici": "^7.24.7",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "nodemon": "^3.1.14"

--- a/PBL4/StripeBot/backend/package.json
+++ b/PBL4/StripeBot/backend/package.json
@@ -8,25 +8,26 @@
     "scrape": "node src/scripts/scraper.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "node --watch src/index.js",
-    "start": "node src/index.js"
+    "start": "node src/index.js",
+    "chunk": "node src/utils/chunker.js",
+    "ingest": "node src/scripts/ingestVector.js",
+    "data:refresh": "npm run scrape && npm run ingest"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "20": "^3.1.9",
     "@google/generative-ai": "^0.24.1",
     "@langchain/core": "^1.1.38",
+    "@xenova/transformers": "^2.17.2",
     "cheerio": "^1.2.0",
     "cors": "^2.8.6",
     "dotenv": "^17.4.1",
     "express": "^5.2.1",
     "js-tiktoken": "^1.0.21",
-    "nvm": "^0.0.4",
     "pg": "^8.20.0",
     "pgvector": "^0.2.1",
-    "undici": "^7.24.7",
-    "use": "^3.1.1"
+    "undici": "^7.24.7"
   },
   "devDependencies": {
     "nodemon": "^3.1.14"

--- a/PBL4/StripeBot/backend/src/app.js
+++ b/PBL4/StripeBot/backend/src/app.js
@@ -1,7 +1,7 @@
 const express = require("express");
 const chatRoutes = require("./routes/chat.routes");
 const { errorMiddleware } = require("./middlewares/error.middleware");
-const pool = require("./config/db");
+const ragRoutes = require("./routes/rag.routes");
 
 // Create an Express application instance
 const app = express();
@@ -11,15 +11,7 @@ app.use(express.json());
 
 // Define routes for the chat API
 app.use("/api/chat", chatRoutes);
-
-app.get("/health", async (req, res) => {
-  try {
-    const r = await pool.query("SELECT NOW() AS now");
-    res.json({ ok: true, db: true, time: r.rows[0].now });
-  } catch (err) {
-    res.status(503).json({ ok: false, db: false, error: err.message });
-  }
-});
+app.use("/api/rag", ragRoutes);
 
 // Handle errors centrally using custom middleware
 app.use(errorMiddleware);

--- a/PBL4/StripeBot/backend/src/controllers/rag.controller.js
+++ b/PBL4/StripeBot/backend/src/controllers/rag.controller.js
@@ -1,0 +1,40 @@
+const pool = require("../config/db");
+const { hybridSearch } = require("../services/hybridRagService");
+const { AppError } = require("../utils/AppError");
+const { ERROR_CODES, RESPONSE_MESSAGES } = require("../constants/apiResponse");
+
+const getHealth = async (req, res, next) => {
+  try {
+    const r = await pool.query("SELECT NOW() AS now");
+    res.json({ ok: true, db: true, time: r.rows[0].now });
+  } catch (err) {
+    err.statusCode = 503;
+    next(err);
+  }
+};
+
+const handleRagSearch = async (req, res, next) => {
+  try {
+    const { query, keywordLimit, semanticLimit, finalLimit } = req.body || {};
+    const q = typeof query === "string" ? query.trim() : "";
+    if (!q) {
+      return next(
+        new AppError(
+          400,
+          ERROR_CODES.INVALID_PROMPT,
+          RESPONSE_MESSAGES.INVALID_PROMPT,
+        ),
+      );
+    }
+    const out = await hybridSearch(q, {
+      keywordLimit,
+      semanticLimit,
+      finalLimit,
+    });
+    res.json(out);
+  } catch (err) {
+    next(err);
+  }
+};
+
+module.exports = { getHealth, handleRagSearch };

--- a/PBL4/StripeBot/backend/src/mcp/mcpServer.js
+++ b/PBL4/StripeBot/backend/src/mcp/mcpServer.js
@@ -1,0 +1,388 @@
+/**
+ * @fileoverview MCP (Model Context Protocol) Server for Stripe Customer Service Agent
+ *
+ * Exposes two tools to any MCP-compatible LLM host (Claude Desktop, etc.):
+ *   1. `get_stripe_status`  – fetches live Stripe system status from status.stripe.com
+ *   2. `web_search`         – performs a web search via Google Custom Search JSON API (free tier)
+ *
+ * Transport: stdio  (the host process spawns this script and communicates over stdin/stdout)
+ *
+ * Usage:
+ *   npm run mcp
+ *   node src/mcp/mcpServer.js
+ *
+ * Loads `.env` from cwd (same as other backend scripts).
+ *
+ * Required environment variables:
+ *   GOOGLE_API_KEY           – your Google Cloud API key
+ *                              (enable "Custom Search API" at https://console.cloud.google.com)
+ *   GOOGLE_SEARCH_ENGINE_ID  – your Programmable Search Engine ID
+ *                              (create one at https://programmablesearchengine.google.com)
+ *
+ * Free tier limits (as of 2024):
+ *   - 100 search queries per day at no cost
+ *   - Max 10 results per request
+ *
+ * @author  Niru K. Magar
+ * @version 2.0.0
+ */
+require("dotenv").config();
+
+const { McpServer } = require("@modelcontextprotocol/sdk/server/mcp.js");
+const {
+  StdioServerTransport,
+} = require("@modelcontextprotocol/sdk/server/stdio.js");
+const { z } = require("zod");
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Public Stripe status JSON endpoint – no auth required*/
+const STRIPE_STATUS_URL = "https://status.stripe.com/api/v2/summary.json";
+/**
+ * Google Custom Search JSON API endpoint.
+ * Docs: https://developers.google.com/custom-search/v1/reference/rest/v1/cse/list
+ *
+ * Query params we use:
+ *   key  – your GOOGLE_API_KEY
+ *   cx   – your GOOGLE_SEARCH_ENGINE_ID
+ *   q    – the search query string
+ *   num  – number of results (1–10)
+ */
+const GOOGLE_SEARCH_URL = "https://www.googleapis.com/customsearch/v1";
+
+/** Default number of results to fetch from Google (max allowed per request: 10) */
+const DEFAULT_RESULT_COUNT = 5;
+
+/**
+ * @param {string} name - Env var name
+ * @returns {string} Trimmed non-empty value
+ * @throws {Error} If missing or blank
+ */
+function requireEnv(name) {
+  const v = process.env[name];
+  if (v === undefined || String(v).trim() === "") {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return String(v).trim();
+}
+
+// ---------------------------------------------------------------------------
+// Helper utilities
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps a raw Stripe component status string to a human-readable label with emoji.
+ *
+ * Stripe returns values like "operational", "degraded_performance", etc.
+ * We map these to friendly strings so Claude can present them cleanly.
+ *
+ * @param {string} status - Raw status string from the Stripe status API
+ * @returns {string} Human-readable label e.g. "✅ Operational"
+ */
+
+function getFriendlyStatus(status) {
+  const map = {
+    operational: "✅ Operational",
+    degraded_performance: "⚠️  Degraded Performance",
+    partial_outage: "🔶 Partial Outage",
+    major_outage: "🔴 Major Outage",
+    under_maintenance: "🔧 Under Maintenance",
+  };
+  // Fallback: if Stripe ever adds a new status we haven't mapped, show it raw
+  return map[status] ?? `❓ Unknown (${status})`;
+}
+
+/**
+ * Fetches a URL and returns the parsed JSON body.
+ *
+ * Centralising fetch logic here means:
+ *   - One place to add retries / timeouts later
+ *   - Consistent error messages across all tool handlers
+ *   - Keeps handler code clean and focused on business logic
+ *
+ * @async
+ * @param {string} url               - Fully-formed URL to request
+ * @param {RequestInit} [options={}] - Optional fetch options (headers, method…)
+ * @returns {Promise<unknown>}        Parsed JSON from the response body
+ * @throws {Error} If the HTTP status is not 2xx, or the body is not valid JSON
+ */
+
+async function fetchJson(url, options = {}) {
+  const res = await fetch(url, options);
+
+  if (!res.ok) {
+    // Read the body text for a richer error message
+    const body = await res.text().catch(() => "(unreadable body)");
+    throw new Error(`HTTP ${res.status} ${res.statusText} — ${url}\n${body}`);
+  }
+
+  return res.json();
+}
+
+// ---------------------------------------------------------------------------
+//  Tool handler – Stripe Status
+// ---------------------------------------------------------------------------
+
+/**
+ * Retrieves the current live status of all Stripe services.
+ *
+ * Hits the public Stripe status page API (no auth needed) and formats:
+ *   - Overall indicator and plain-English description
+ *   - Per-component status table (API, Webhooks, Dashboard, etc.)
+ *   - Any active incidents with the most recent update body + timestamp
+ *
+ * This is useful when a customer reports something like "my payments are failing"
+ * and the agent needs to check whether Stripe itself is experiencing issues.
+ *
+ * @async
+ * @returns {Promise<{ content: Array<{ type: "text"; text: string }> }>}
+ *   MCP-compatible result with Markdown-formatted status report
+ * @throws {Error} If the Stripe status API is unreachable
+ */
+
+async function handleGetStripeStatus() {
+  const data = await fetchJson(STRIPE_STATUS_URL);
+
+  // Overall headline status
+  const overall = data.status ?? {};
+  const lines = [
+    "## Stripe System Status",
+    `**Overall:** ${getFriendlyStatus(overall.indimjt4rtcator ?? "unknown")} — ${overall.description ?? "No description"}`,
+    "",
+  ];
+
+  // Component-level breakdown
+  // Filter out "group: true" entries – these are parent roll-up rows, not real components
+  const components = (data.components ?? []).filter(
+    // Hide child components that are already rolled up by a parent
+    (c) => !c.group,
+  );
+  if (components.length > 0) {
+    lines.push("### Components");
+    for (const c of components) {
+      lines.push(`- **${c.name}**: ${getFriendlyStatus(c.status)}`);
+    }
+    lines.push("");
+  }
+
+  // Active incidents (empty array means all clear)
+  const incidents = data.incidents ?? [];
+  if (incidents.length > 0) {
+    lines.push("### Active Incidents");
+    for (const inc of incidents) {
+      // incident_updates is newest-first, so index 0 = latest update
+      const latestUpdate = inc.incident_updates?.[0];
+      lines.push(`- **${inc.name}** *(${inc.status})*`);
+      if (latestUpdate) {
+        lines.push(
+          `  > ${latestUpdate.body}\n` +
+            `  > *Updated: ${new Date(latestUpdate.created_at).toUTCString()}*`,
+        );
+      }
+    }
+  } else {
+    lines.push("_No active incidents. All systems operational._");
+  }
+
+  return { content: [{ type: "text", text: lines.join("\n") }] };
+}
+// ---------------------------------------------------------------------------
+// Tool handler – Google Web Search
+// ---------------------------------------------------------------------------
+
+/**
+ * Performs a web search using the Google Custom Search JSON API.
+ *
+ * WHY GOOGLE CUSTOM SEARCH?
+ *   - Free tier: 100 queries/day, no credit card required for basic use
+ *   - Returns structured JSON with title, link, and snippet per result
+ *   - Backed by the same index as google.com — high-quality results
+ *
+ * HOW IT WORKS (step by step):
+ *   1. Read GOOGLE_API_KEY and GOOGLE_SEARCH_ENGINE_ID from env
+ *   2. Build the request URL with query params (key, cx, q, num)
+ *   3. GET the URL — Google returns a JSON object with an "items" array
+ *   4. Map each item to { title, link, snippet } and format as Markdown
+ *   5. Return the Markdown string inside an MCP content block
+ *
+ * Google API response shape (simplified):
+ * {
+ *   searchInformation: { totalResults, formattedTotalResults, searchTime },
+ *   items: [
+ *     { title, link, displayLink, snippet, ... },
+ *     ...
+ *   ]
+ * }
+ *
+ * @async
+ * @param {{ query: string; count?: number }} params
+ *   @param {string}  params.query       - Search query string
+ *   @param {number}  [params.count=5]   - Results to return (1–10, Google's hard limit)
+ * @returns {Promise<{ content: Array<{ type: "text"; text: string }> }>}
+ *   MCP-compatible result with Markdown-formatted search results
+ * @throws {Error} If required env vars are missing or the Google API call fails
+ */
+
+async function handleWebSearch({ query, count = DEFAULT_RESULT_COUNT }) {
+  // Step 1 – Validate env vars up-front (fail fast with clear messages)
+  const apiKey = requireEnv("GOOGLE_API_KEY");
+  const searchEngineId = requireEnv("GOOGLE_SEARCH_ENGINE_ID");
+
+  // Step 2 – Build the Google Custom Search URL
+  //
+  // Google's API only accepts `num` between 1 and 10 per request.
+  // If the caller asks for more, we clamp silently rather than throwing.
+  const safeCount = Math.min(Math.max(1, count), 10);
+
+  const url = new URL(GOOGLE_SEARCH_URL);
+  url.searchParams.set("key", apiKey); // API authentication
+  url.searchParams.set("cx", searchEngineId); // Which search engine to use
+  url.searchParams.set("q", query); // The actual search query
+  url.searchParams.set("num", String(safeCount)); // How many results to return
+
+  // Step 3 – Call Google's API (no special headers needed — auth is in the URL)
+  const data = await fetchJson(url.toString());
+
+  // Step 4 – Handle empty results
+  // Google omits the "items" key entirely when there are zero results
+
+  const items = data.items ?? [];
+
+  if (items.length === 0) {
+    return {
+      content: [
+        {
+          type: "text",
+          text:
+            `No results found for: "${query}"\n\n` +
+            `Try rephrasing your query or broadening the search terms.`,
+        },
+      ],
+    };
+  }
+
+  // Step 5 – Format results as readable Markdown
+  //
+  // Each Google result item contains:
+  //   item.title       – the page title
+  //   item.link        – the full canonical URL
+  //   item.displayLink – the short domain shown in Google (e.g. "stripe.com")
+  //   item.snippet     – a short excerpt showing relevant passage from the page
+  const lines = [
+    `## Google Search Results for: "${query}"`,
+    `*Showing ${items.length} of ${data.searchInformation?.formattedTotalResults ?? "?"} results` +
+      ` — search time: ${data.searchInformation?.formattedSearchTime ?? "?"}s*`,
+    "",
+  ];
+
+  items.forEach((item, i) => {
+    lines.push(`### ${i + 1}. ${item.title}`);
+    lines.push(`**URL:** ${item.link}`);
+    lines.push(`**Source:** ${item.displayLink}`);
+    if (item.snippet) {
+      // Snippets sometimes contain newlines that break Markdown — collapse them
+      lines.push(item.snippet.replace(/\n/g, " "));
+    }
+    lines.push(""); // blank line between each result for readability
+  });
+
+  return { content: [{ type: "text", text: lines.join("\n") }] };
+}
+
+// ---------------------------------------------------------------------------
+// Server bootstrap
+// ---------------------------------------------------------------------------
+
+/**
+ * Initialises and starts the MCP server.
+ *
+ * Steps performed:
+ *   1. Create an McpServer instance with name + version metadata
+ *   2. Register `get_stripe_status` tool (no input params needed)
+ *   3. Register `web_search` tool with Zod-validated input schema
+ *   4. Attach StdioServerTransport — host spawns us as a subprocess
+ *   5. Call server.connect() — blocks forever, listening for MCP messages
+ *
+ * @async
+ * @returns {Promise<void>}
+ */
+
+async function main() {
+  // Step 1 – Create the server
+  const server = new McpServer({
+    name: "stripe-bot-mcp",
+    version: "2.0.0",
+  });
+
+  // -------------------------------------------------------------------
+  // Tool: get_stripe_status
+  // No input params – just call it and get live status
+  // -------------------------------------------------------------------
+
+  // Step 2 – Register: get_stripe_status
+  // Empty schema ({}) because this tool takes zero arguments from the LLM.
+
+  server.tool(
+    "get_stripe_status",
+    "Fetches the current live status of all Stripe services (API, Dashboard, Webhooks, etc.) " +
+      "and reports any active incidents. Use this whenever a customer reports Stripe is down " +
+      "or behaving unexpectedly.",
+    {}, // ← empty schema = no parameters required
+    async () => handleGetStripeStatus(),
+  );
+
+  // -------------------------------------------------------------------
+  // Tool: web_search
+  // Accepts a query string and optional result count
+  // -------------------------------------------------------------------
+
+  // Step 3 – Register: web_search
+  // Zod schema tells the MCP host exactly what the LLM must pass in.
+  // `query` is required; `count` is optional with a sensible default.
+
+  server.tool(
+    "web_search",
+    "Searches the web using Google Custom Search (free tier: 100 queries/day). " +
+      "Useful for finding Stripe documentation, changelogs, error code explanations, " +
+      "community answers, or any information not covered by the local knowledge base.",
+    {
+      query: z
+        .string()
+        .min(1)
+        .describe(
+          "The search query string (e.g. 'Stripe webhook signature verification error')",
+        ),
+      count: z
+        .number()
+        .int()
+        .min(1)
+        .max(10)
+        .optional()
+        .describe(
+          "Number of results to return (default 5, max 10 — Google hard limit)",
+        ),
+    },
+    async (params) => handleWebSearch(params),
+  );
+
+  // Steps 4 & 5 – Connect stdio transport and start the event loop
+  // StdioServerTransport pipes MCP JSON-RPC messages through stdin/stdout.
+  // After connect() the server is live — it processes calls until the host closes the pipe.
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+
+  // Always log to stderr — stdout belongs to the MCP protocol, never write to it directly
+  console.error(
+    "✅ Stripe MCP server v2.0.0 running (stdio) — Google Custom Search enabled",
+  );
+}
+
+// Entry point
+// If startup fails (bad imports, missing SDK, etc.) log clearly and exit non-zero
+// so the MCP host knows the server didn't launch successfully
+main().catch((err) => {
+  console.error("Fatal error during MCP server startup:", err);
+  process.exit(1);
+});

--- a/PBL4/StripeBot/backend/src/routes/rag.routes.js
+++ b/PBL4/StripeBot/backend/src/routes/rag.routes.js
@@ -1,0 +1,9 @@
+const express = require("express");
+const { getHealth, handleRagSearch } = require("../controllers/rag.controller");
+
+const ragRouter = express.Router();
+
+ragRouter.get("/", getHealth);
+ragRouter.post("/search", handleRagSearch);
+
+module.exports = ragRouter;

--- a/PBL4/StripeBot/backend/src/scripts/ingestVector.js
+++ b/PBL4/StripeBot/backend/src/scripts/ingestVector.js
@@ -1,0 +1,97 @@
+require("dotenv").config();
+/** fs: File system module for reading and writing files */
+const fs = require("fs/promises");
+/** path: Path module for working with file paths */
+const path = require("path");
+/** toSql: function to convert the embedding to a SQL vector */
+const { toSql } = require("pgvector");
+/** pool: the database connection pool */
+const pool = require("../config/db");
+/** embedText: function to embed the text */
+const { embedText } = require("../services/embeddingService");
+/** chunkScrapedDocuments: function to chunk the scraped documents */
+const { chunkScrapedJSON } = require("../utils/chunker");
+
+/** main: main function to ingest the vectors */
+async function main() {
+  /** jsonPath: the path to the JSON file containing the scraped documents */
+  const jsonPath = path.join(
+    process.cwd(),
+    "data",
+    "stripe_docs",
+    "scraped.json",
+  );
+  const docs = JSON.parse(await fs.readFile(jsonPath, "utf8"));
+  const chunks = chunkScrapedJSON(docs);
+
+  console.log("📥 Ingest:", docs.length, "doc(s) →", chunks.length, "chunk(s)");
+
+  /** client: the database client */
+  const client = await pool.connect();
+  /** try: try to ingest the vectors */
+  try {
+    /** if INGEST_APPEND is not set to 1, truncate the stripe_doc_chunks table */
+    if (process.env.INGEST_APPEND !== "1") {
+      await client.query("TRUNCATE stripe_doc_chunks RESTART IDENTITY");
+      console.log(
+        "🗑️  Truncated stripe_doc_chunks (set INGEST_APPEND=1 to skip)",
+      );
+    }
+    /** n: the number of chunks ingested
+     * for each chunk, embed the text and insert the vector into the database
+     */
+    let n = 0;
+    /** go through each chunk produced from scraped.json */
+    for (const ch of chunks) {
+      /** embed the text of the chunk */
+      const emb = await embedText(ch.content);
+      const m = ch.metadata;
+      /** insert the vector into the database
+       * embedding (via toSql(emb) for pgvector), metadata as JSON.
+       * ON CONFLICT (source_doc_id, chunk_index) DO UPDATE SET: if the chunk already exists, update the existing chunk
+       * why update: to keep the chunk up to date with the latest version of the document
+       */
+      await client.query(
+        `INSERT INTO stripe_doc_chunks
+   (source_doc_id, chunk_index, source_url, title, content, embedding, metadata)
+   VALUES ($1,$2,$3,$4,$5,$6::vector,$7::jsonb)
+   ON CONFLICT (source_doc_id, chunk_index) DO UPDATE SET
+     source_url = EXCLUDED.source_url,
+     title = EXCLUDED.title,
+     content = EXCLUDED.content,
+     embedding = EXCLUDED.embedding,
+     metadata = EXCLUDED.metadata`,
+        [
+          m.source_id,
+          m.chunk_index,
+          m.url,
+          m.title,
+          ch.content,
+          toSql(emb),
+          JSON.stringify(m),
+        ],
+      );
+      /** increment the number of chunks ingested */
+      n += 1;
+      /** log the progress every 20 chunks
+       */
+      if (n % 20 === 0) console.log(`... embedded ${n}/${chunks.length}`);
+    }
+    console.log("✅ Ingest complete:", n, "row(s) upserted");
+    /** release the database client */
+  } finally {
+    client.release();
+  }
+  /** end the database connection */
+  await pool.end();
+}
+
+/** if the script is run directly, run the main function */
+if (process.argv[1]?.endsWith("ingestVector.js")) {
+  main().catch((e) => {
+    console.error("❌ Ingest failed:", e.message);
+    process.exit(1);
+  });
+}
+
+module.exports = { main };

--- a/PBL4/StripeBot/backend/src/scripts/scraper.js
+++ b/PBL4/StripeBot/backend/src/scripts/scraper.js
@@ -209,8 +209,6 @@ async function scrapeDoc(url, category) {
       };
       title = categoryTitles[category] ?? "Documentation";
     }
-    console.log("hello");
-    console.log("this is not ");
     /**
      * content: raw text from the page
      * replace multiple whitespace with single space
@@ -218,7 +216,9 @@ async function scrapeDoc(url, category) {
      * trim leading/trailing spaces and line breaks
      */
     const cleanContent = content
-      .replace(/\s+/g, " ")
+      .replace(/\r\n/g, "\n")
+      .replace(/[ \t]+/g, " ")
+      .replace(/\n{3,}/g, "\n\n")
       .replace(/sk_test_[A-Za-z0-9]+/g, "sk_test_[REDACTED]")
       .replace(/sk_live_[A-Za-z0-9]+/g, "sk_live_[REDACTED]")
       .replace(/whsec_[A-Za-z0-9]+/g, "whsec_[REDACTED]")

--- a/PBL4/StripeBot/backend/src/services/embeddingService.js
+++ b/PBL4/StripeBot/backend/src/services/embeddingService.js
@@ -1,0 +1,61 @@
+/** undici: HTTP client for Node.js
+ * use for implement the standard fetch API in Node.js
+ */
+const { fetch, Headers, Request, Response } = require("undici");
+/** xenova/transformers: pipeline for feature extraction
+ * @xenova/transformers: JS library to run ML model locally on CPU
+ * Transformers: refers to a type of AI model architecture
+ * pipeline: helper that loads and runs transformer models easily in JavaScript for feature extraction
+ */
+const { pipeline } = require("@xenova/transformers");
+
+// @xenova/transformers expects Web APIs (Node < 18)
+if (typeof globalThis.fetch === "undefined") globalThis.fetch = fetch;
+if (typeof globalThis.Headers === "undefined") globalThis.Headers = Headers;
+if (typeof globalThis.Request === "undefined") globalThis.Request = Request;
+if (typeof globalThis.Response === "undefined") globalThis.Response = Response;
+
+/**
+ * "Xenova/all-MiniLM-L6-v2": embedding model, converts text → 384-dimensional vector (numbers)
+ * 384 dimension: every sentence is converted into a list of 384 numbers
+ * why: it's a small model that is fast and accurate for feature extraction
+ */
+
+const MODEL_ID = "Xenova/all-MiniLM-L6-v2";
+
+/** @type {import('@xenova/transformers').FeatureExtractionPipeline | null} */
+
+let embedder = null;
+
+/**
+ * embedText: function converts a piece of text into a 384-dimensional embedding vector using an AI model.
+ * return: JavaScript array, length = 384
+ */
+async function embedText(text) {
+  if (!embedder) {
+    embedder = await pipeline("feature-extraction", MODEL_ID);
+  }
+  const t = String(text || "").slice(0, 8000);
+  /** embedder: the embedding model
+   * t: processed text input to embed
+   * pooling: "mean": average the embeddings of the tokens to get a single vector
+   * normalize: true: normalize the embedding to have a length of 1
+   */
+  const out = await embedder(t, { pooling: "mean", normalize: true });
+  const data = out.data;
+  return Array.from(data);
+}
+
+/** @param {string[]} texts
+ * takes multiple texts and returns multiple embedding vectors
+ * vectors: array of embedding vectors
+ */
+async function embedTexts(texts) {
+  const vectors = [];
+  for (const t of texts) {
+    vectors.push(await embedText(t));
+  }
+  return vectors;
+}
+
+module.exports = { embedText, embedTexts };

--- a/PBL4/StripeBot/backend/src/services/hybridRagService.js
+++ b/PBL4/StripeBot/backend/src/services/hybridRagService.js
@@ -1,0 +1,123 @@
+const { toSql } = require("pgvector");
+const pool = require("../config/db");
+const { embedText } = require("./embeddingService");
+/** RRF_K (Reciprocal Rank Fusion): the number of results to return */
+const RRF_K = 60;
+
+/**
+ * Reciprocal Rank Fusion over two ranked lists.
+ * @param {{ id: number }[][]} lists
+ * This function merges multiple ranked search results into a single scoring system using Reciprocal Rank Fusion.
+ * lists: array of ranked results
+ * k: the number of results to return
+ * return: map of id to score
+ * search: Text → embedding (384 numbers) → similarity search → list of results
+ */
+function reciprocalRankFusion(lists, k = RRF_K) {
+  const scores = new Map();
+  for (const list of lists) {
+    list.forEach((row, rank) => {
+      const id = row.id;
+      /** 1 / (k + rank + 1): rank 1 → high score, rank 10 → low score */
+      scores.set(id, (scores.get(id) || 0) + 1 / (k + rank + 1));
+    });
+  }
+  return scores;
+}
+
+/**
+ * Hybrid search: keyword (FTS-full text search) + semantic (cosine via pgvector), fused with RRF.
+ * @param {string} query
+ * @param {{ keywordLimit?: number, semanticLimit?: number, finalLimit?: number }} [opts]
+ */
+async function hybridSearch(query, opts = {}) {
+  const keywordLimit = opts.keywordLimit ?? 15;
+  const semanticLimit = opts.semanticLimit ?? 15;
+  const finalLimit = opts.finalLimit ?? 8;
+  const q = String(query || "").trim();
+  if (!q) return { results: [], debug: { error: "empty query" } };
+
+  /**
+   * kwRows: results from the keyword search
+   * queryVec: the embedding of the query
+   * embedText: function to embed the query
+   * Promise.all: to run the keyword search and the embedding search in parallel
+   */
+  const [kwRows, queryVec] = await Promise.all([
+    pool.query(
+      `SELECT id, source_url, title, content, chunk_index, source_doc_id,
+              ts_rank_cd(content_tsv, plainto_tsquery('english', $1)) AS kw_rank
+               FROM stripe_doc_chunks
+       WHERE content_tsv @@ plainto_tsquery('english', $1)
+       ORDER BY kw_rank DESC
+       LIMIT $2`,
+      [q, keywordLimit],
+    ),
+    embedText(q),
+  ]);
+
+  /**
+   * semRes: results from the semantic search
+   * queryVec: the embedding of the query
+   * $1::vector: your question’s embedding (queryVec) formatted for pgvector via toSql(queryVec)
+   * embedding <=> $1 — cosine distance between each row’s embedding and the query vector (smaller distance = more similar)
+   * ORDER BY embedding <=> $1::vector: sort the results by the cosine distance
+   * (1 - (embedding <=> $1::vector)) AS sem_score: turns distance into a rough similarity-style score (higher = closer; exact scale depends on pgvector’s cosine distance definition).
+   * LIMIT $2: limit the number of results to the semanticLimit
+   * [toSql(queryVec), semanticLimit]: parameters for the query
+   */
+  const semRes = await pool.query(
+    `SELECT id, source_url, title, content, chunk_index, source_doc_id,
+    (1 - (embedding <=> $1::vector)) AS sem_score
+FROM stripe_doc_chunks
+WHERE embedding IS NOT NULL
+ORDER BY embedding <=> $1::vector
+LIMIT $2`,
+    [toSql(queryVec), semanticLimit],
+  );
+
+  /**
+   * merges two result sets and removes duplicates using id
+   * - Keyword search results
+   * - Semantic (vector) search results
+   * Output = one combined dataset
+   */
+  const byId = new Map();
+  for (const row of kwRows.rows) byId.set(row.id, { ...row });
+  for (const row of semRes.rows) {
+    if (!byId.has(row.id)) byId.set(row.id, { ...row });
+    else Object.assign(byId.get(row.id), row);
+  }
+  /** It takes keyword + semantic search results, ranks them using RRF, sorts them, and returns the top document IDs.*/
+  const rrfScores = reciprocalRankFusion([kwRows.rows, semRes.rows]);
+  const mergedIds = [...rrfScores.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, finalLimit)
+    .map(([id]) => id);
+
+  /** It takes the top document IDs, maps them to their corresponding rows, and returns the full structured search results. */
+  const results = mergedIds.map((id) => {
+    const row = byId.get(id);
+    return {
+      id,
+      sourceUrl: row.source_url,
+      title: row.title,
+      content: row.content,
+      chunkIndex: row.chunk_index,
+      sourceDocId: row.source_doc_id,
+      rrfScore: rrfScores.get(id),
+      kwRank: row.kw_rank ?? null,
+      semScore: row.sem_score ?? null,
+    };
+  });
+
+  return {
+    results,
+    debug: {
+      keywordHits: kwRows.rows.length,
+      semanticHits: semRes.rows.length,
+    },
+  };
+}
+
+module.exports = { hybridSearch };

--- a/PBL4/StripeBot/backend/src/sql/setup_hybrid.sql
+++ b/PBL4/StripeBot/backend/src/sql/setup_hybrid.sql
@@ -1,0 +1,39 @@
+-- Hybrid RAG: dense vectors (semantic) + PostgreSQL full-text (keyword).
+-- Run once in Supabase SQL editor (or psql) against your project database.
+
+CREATE EXTENSION IF NOT EXISTS vector;
+
+-- Chunk-level storage (one row per text chunk; replaces single-row-per-doc for RAG quality)
+CREATE TABLE IF NOT EXISTS stripe_doc_chunks (
+  id BIGSERIAL PRIMARY KEY,
+  source_doc_id TEXT NOT NULL,
+  chunk_index INT NOT NULL,
+  source_url TEXT,
+  title TEXT,
+  content TEXT NOT NULL,
+  content_tsv tsvector GENERATED ALWAYS AS (
+    to_tsvector('english', coalesce(title, '') || ' ' || coalesce(content, ''))
+  ) STORED,
+  embedding vector(384),
+  metadata JSONB DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  UNIQUE (source_doc_id, chunk_index)
+);
+-- Create index for full-text search (keyword search)
+-- GIN-Generalized Inverted Index: a data structure that allows for fast full-text search
+-- content_tsv: converts text into searchable tokens e.g."I love JavaScript"→ ['love', 'javascript']
+CREATE INDEX IF NOT EXISTS stripe_doc_chunks_content_tsv_idx
+  ON stripe_doc_chunks USING GIN (content_tsv);
+
+-- Create index for vector search
+-- HNSW-Hierarchical Navigable Small World Graph: a data structure that allows for fast vector search
+-- Instead of comparing query vector with ALL vectors, HNSW builds a graph of similar vectors
+-- embedding: the vector to search for
+-- vector_cosine_ops: the cosine distance operation-similarity is calculated using cosine distance
+-- m: number of connections per node, more = better accuracy, less = faster search
+-- m = 16: 16 connections per node
+-- ef_construction: controls build quality of index, higher = better accuracy but slower indexing, lower = faster build but less accurate
+CREATE INDEX IF NOT EXISTS stripe_doc_chunks_embedding_hnsw_idx
+  ON stripe_doc_chunks
+  USING hnsw (embedding vector_cosine_ops)
+  WITH (m = 16, ef_construction = 64);


### PR DESCRIPTION
## Summary

Adds a Model Context Protocol (stdio) server so MCP-capable hosts (e.g. Cursor, MCP Inspector) can call two tools: live Stripe platform status and Google Custom Search–backed web search. The backend npm run mcp entrypoint runs the server from src/mcp/mcpServer.js.

## Changes Made

- New MCP server using @modelcontextprotocol/sdk (McpServer + StdioServerTransport).
- get_stripe_status – fetches public Stripe status JSON and returns a short Markdown summary for the client.
- web_search – calls Google Custom Search JSON API with query and optional count (clamped to 1–10), returns Markdown result list.
- package.json – mcp script: node src/mcp/mcpServer.js.

## Configuration

- Variable | Purpose -- | -- GOOGLE_API_KEY | Google Cloud API key (Custom Search API enabled) 
- GOOGLE_SEARCH_ENGINE_ID | Programmable Search Engine ID (cx)
- Load via .env in backend/ (with dotenv if the server imports it) or export in the environment before starting MCP.

## How to run locally
- cd PBL4/StripeBot/backend
- npm run mcp
- Or: npx @modelcontextprotocol/inspector node src/mcp/mcpServer.js (from backend), then exercise Tools in the inspector UI.

## Testing Plan

<!-- Describe how to manually test the changes -->

- npm run mcp
  - starts without throwing (stdio process stays running).
- Inspector (or Cursor MCP):
  - get_stripe_status
  - returns formatted status (not HTML error body).
- web_search with e.g.
{ "query": "Stripe webhooks", "count": 5 }
returns results when both Google env vars are set.

## Notes / risks
- Stripe status URL must match whatever Stripe currently serves as JSON; if the status page changes, update 
- STRIPE_STATUS_URL and the parser accordingly.
- Google quota: free tier limits apply; high tool usage will hit API caps before app logic.
- Secrets: never commit GOOGLE_API_KEY / engine ID; keep them in .env (gitignored).

## Checklist

- [ ] Code is properly formatted and linted
- [ ] No console.log or debugging code left in
- [ ] Feature works as expected
- [ ] Linked issues: Closes #885 